### PR TITLE
fix: persist copilot setup workspace

### DIFF
--- a/dagger-modules/copilot-setup/README.md
+++ b/dagger-modules/copilot-setup/README.md
@@ -22,6 +22,17 @@ dagger call --output ./copilot-prepared prepare-node-workspace-directory \
   --playwright-install
 ```
 
+For a smaller, faster host handoff, export a compressed setup bundle instead of the
+entire prepared workspace:
+
+```bash
+dagger call --output ./copilot-bundle prepare-node-workspace-bundle \
+  --source . \
+  --node-auth-token env:NODE_AUTH_TOKEN \
+  --package-paths ".,sl-demos,sl-demos/src/apps/consumer" \
+  --playwright-install
+```
+
 Available switches:
 
 - `--playwright-install`

--- a/dagger-modules/copilot-setup/src/index.ts
+++ b/dagger-modules/copilot-setup/src/index.ts
@@ -27,6 +27,14 @@ function workspacePath(packagePath: string): string {
   return packagePath === "." ? "/workspace" : `/workspace/${packagePath}`;
 }
 
+function relativeWorkspacePath(packagePath: string): string {
+  return packagePath === "." ? "." : packagePath;
+}
+
+function uniqueEntries(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
 function writeNpmrcScript(npmrcPaths: string[]): string {
   return [
     "set -euo pipefail",
@@ -143,6 +151,46 @@ function buildScript(
   return lines.join("\n");
 }
 
+function bundleEntries(
+  packagePaths: string[],
+  options: {
+    playwrightInstall: boolean;
+  },
+): string[] {
+  const entries = packagePaths.flatMap((packagePath) => {
+    const relativePath = relativeWorkspacePath(packagePath);
+    return relativePath === "." ?
+        [".npmrc", "node_modules"]
+      : [`${relativePath}/.npmrc`, `${relativePath}/node_modules`];
+  });
+
+  if (options.playwrightInstall) {
+    entries.push(".playwright-browsers");
+  }
+
+  return uniqueEntries(entries);
+}
+
+function bundleScript(entries: string[]): string {
+  return [
+    "set -euo pipefail",
+    "mkdir -p /bundle",
+    "entries=()",
+    ...entries.map((entry) => `entries+=(${shellQuote(entry)})`),
+    "existing=()",
+    'for entry in "${entries[@]}"; do',
+    '  if [ -e "/workspace/${entry}" ]; then',
+    '    existing+=("${entry}")',
+    "  fi",
+    "done",
+    'if [ "${#existing[@]}" -eq 0 ]; then',
+    '  echo "No bundle entries found to export" >&2',
+    "  exit 1",
+    "fi",
+    'tar -czf /bundle/copilot-workspace.tar.gz -C /workspace "${existing[@]}"',
+  ].join("\n");
+}
+
 @object()
 export class CopilotSetup {
   @func()
@@ -215,5 +263,50 @@ export class CopilotSetup {
     ]);
 
     return workspace.directory("/workspace");
+  }
+
+  @func()
+  async prepareNodeWorkspaceBundle(
+    source: Directory,
+    nodeAuthToken: Secret,
+    packagePaths = ".",
+    playwrightInstall = false,
+    firebaseTools = false,
+  ): Promise<Directory> {
+    const packages = splitCsv(packagePaths);
+    let container = dag.container().from("node:24-bookworm");
+
+    if (firebaseTools) {
+      container = withTooling(container, {
+        firebaseTools,
+      });
+    }
+
+    const workspace = withCopiedWorkspace(
+      container,
+      source,
+      nodeAuthToken,
+      packages,
+    ).withExec([
+      "bash",
+      "-lc",
+      buildScript(packages, {
+        buildPaths: [],
+        playwrightInstall,
+        persistPlaywrightBrowsers: true,
+      }),
+    ]);
+
+    const bundle = workspace.withExec([
+      "bash",
+      "-lc",
+      bundleScript(
+        bundleEntries(packages, {
+          playwrightInstall,
+        }),
+      ),
+    ]);
+
+    return bundle.directory("/bundle");
   }
 }


### PR DESCRIPTION
## Summary
- add an exportable Copilot setup function that returns a prepared workspace directory
- persist Playwright browsers into the exported workspace for the later agent session
- document the workflow pattern for restoring the prepared workspace onto the runner

## Why
The existing Copilot Dagger setup prepares dependencies inside Dagger, but the later coding-agent step runs against the runner checkout. Exporting and restoring the prepared workspace makes installed dependencies and browser binaries available to the agent session.