### PR TITLE
Add Check PR Title GitHub Action

### DIFF
--- a/.github/actions/check-pr-title/action.yml
+++ b/.github/actions/check-pr-title/action.yml
@@ -1,0 +1,19 @@
+name: 'Check PR Title'
+description: 'Validates PR title against Conventional Commits and posts a comment on failure.'
+inputs:
+  github-token:
+    description: 'GitHub Token for Dagger'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: PR Title Check
+      run: |
+        # Note: Once the PR is merged to main, you can use the main branch reference
+        dagger call -m github.com/StaytunedLLP/daggerverse \
+          check-pr-title \
+          --event-file=${{ github.event_path }} \
+          --github-token=env:GITHUB_TOKEN
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/src/checks/pr-checks.ts
+++ b/src/checks/pr-checks.ts
@@ -136,7 +136,23 @@ async function postPrComment(
 ): Promise<void> {
   await dag
     .container()
-    .from("ghcr.io/cli/cli:2.89.0")
+    .from("node:24-bookworm-slim")
+    .withExec(["apt-get", "update"])
+    .withExec(["apt-get", "install", "-y", "curl", "gpg"])
+    .withExec(["mkdir", "-p", "-m", "0755", "/etc/apt/keyrings"])
+    .withExec([
+      "sh",
+      "-c",
+      "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+    ])
+    .withExec(["chmod", "go+r", "/etc/apt/keyrings/githubcli-archive-keyring.gpg"])
+    .withExec([
+      "sh",
+      "-c",
+      'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
+    ])
+    .withExec(["apt-get", "update"])
+    .withExec(["apt-get", "install", "-y", "gh"])
     .withSecretVariable("GH_TOKEN", githubToken)
     .withNewFile("/tmp/comment.md", comment)
     .withExec(


### PR DESCRIPTION
Created a new composite GitHub Action `check-pr-title` that leverages Dagger to validate PR titles. This centralizes the logic and simplifies usage in other repositories.

---
*PR created automatically by Jules for task [2417793230284316038](https://jules.google.com/task/2417793230284316038) started by @abhayraj-yadav-st4*