### PR TITLE
Move pipelines and documentation to ubuntu-latest

### DIFF
--- a/.agent/skills/devops-optimization/SKILL.md
+++ b/.agent/skills/devops-optimization/SKILL.md
@@ -8,7 +8,7 @@ description: Architect-level DevOps optimization for Dagger workflows on ARC wit
 This skill defines optimization standards for Dagger workflows in Staytuned repositories, with a focus on:
 
 - direct `dagger` CLI usage in CI (not wrapper actions)
-- ARC infrastructure alignment (`st-arc`)
+- Infrastructure alignment (`ubuntu-latest`)
 - lockfile-first and cache-volume-first architecture
 - reusable TypeScript module composition from shared helpers
 
@@ -25,12 +25,12 @@ A practical architecture + execution policy for CI/CD and Dagger modules so pipe
 
 ## Procedure: Daggerizing a Workflow
 
-### 1. Runner Setup (st-arc)
+### 1. Runner Setup (ubuntu-latest)
 
-All Daggerized workflows **must** run on `st-arc`.
+All Daggerized workflows **must** run on `ubuntu-latest`.
 
 ```yaml
-runs-on: st-arc
+runs-on: ubuntu-latest
 ```
 
 ### 2. Bootstrapping
@@ -38,7 +38,7 @@ runs-on: st-arc
 Always include the bootstrap step to connect to the internal Dagger engine.
 
 ```yaml
-- name: Bootstrap Dagger (ARC)
+- name: Bootstrap Dagger
   uses: staytunedllp/devops/.github/actions/dagger-bootstrap@main
   with:
     namespace: dagger
@@ -57,11 +57,11 @@ Standard pattern:
 ```yaml
 jobs:
   ci:
-    runs-on: st-arc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Bootstrap Dagger (ARC)
+      - name: Bootstrap Dagger
         uses: staytunedllp/devops/.github/actions/dagger-bootstrap@main
         with:
           namespace: dagger
@@ -148,7 +148,7 @@ async test(
 ```yaml
 jobs:
   test:
-    runs-on: st-arc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Bootstrap Dagger

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,7 +19,7 @@ jobs:
   # Job to run PR checks
   pr-checks:
     name: Run PR Checks
-    runs-on: st-arc
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Treat this section as the highest-priority implementation policy for this reposi
    - Use Dagger layer caching and `cacheVolume` mounts intentionally.
 
 2. **Infrastructure security**
-   - All Dagger operations in GitHub Actions must run on internal ARC infrastructure (`st-arc`).
+   - All Dagger operations in GitHub Actions must run on `ubuntu-latest`.
 
 3. **Generalization (multi-repo ready)**
    - Do not hardcode repository-specific paths, scripts, or assumptions.
@@ -25,16 +25,16 @@ Treat this section as the highest-priority implementation policy for this reposi
 
 Any GitHub Actions job that invokes Dagger must:
 
-1. set `runs-on: st-arc`
-2. bootstrap the Dagger engine on ARC before any Dagger call
+1. set `runs-on: ubuntu-latest`
+2. bootstrap the Dagger engine before any Dagger call
 
 ```yaml
 jobs:
   job_name:
-    runs-on: st-arc
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Bootstrap Dagger (ARC)
+      - name: Bootstrap Dagger
         uses: staytunedllp/devops/.github/actions/dagger-bootstrap@main
         with:
           namespace: dagger


### PR DESCRIPTION
Moved the CI pipelines from st-arc to ubuntu-latest and updated the corresponding documentation in AGENTS.md and the AI skill definition to ensure consistency. Verified that the project builds correctly after the changes.

---
*PR created automatically by Jules for task [14477646085874316877](https://jules.google.com/task/14477646085874316877) started by @abhayraj-yadav-st4*