### PR TITLE
🧪 test: add validatePrTitle tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1339,7 +1338,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1814,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
+    "test": "npm run build && node --test \"dist/**/*.test.js\"",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "publishConfig": {

--- a/src/checks/pr-checks.test.ts
+++ b/src/checks/pr-checks.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { validatePrTitle } from "./pr-checks.js";
+
+describe("validatePrTitle", () => {
+  describe("valid titles", () => {
+    it("should accept basic conventional commits", () => {
+      validatePrTitle("feat: add new feature");
+      validatePrTitle("fix: resolve bug");
+      validatePrTitle("chore: update dependencies");
+      validatePrTitle("docs: update readme");
+      validatePrTitle("style: format code");
+      validatePrTitle("refactor: extract method");
+      validatePrTitle("perf: improve query speed");
+      validatePrTitle("test: add unit tests");
+    });
+
+    it("should accept commits with scopes", () => {
+      validatePrTitle("feat(api): add new endpoint");
+      validatePrTitle("fix(ui): resolve layout issue");
+      validatePrTitle("chore(deps): update react");
+      validatePrTitle("feat(core-module): handle hyphenated scopes");
+      validatePrTitle("fix(core.module): handle dotted scopes");
+    });
+
+    it("should accept commits with breaking change indicators", () => {
+      validatePrTitle("feat!: break backwards compatibility");
+      validatePrTitle("fix(api)!: change response format");
+    });
+  });
+
+  describe("invalid titles", () => {
+    it("should throw for an invalid prefix", () => {
+      assert.throws(
+        () => validatePrTitle("update: add new feature"),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("The type must be one of:"),
+            true
+          );
+          return true;
+        }
+      );
+    });
+
+    it("should throw when missing a space after the colon", () => {
+      assert.throws(
+        () => validatePrTitle("feat:add new feature"),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("A space MUST follow the terminal colon"),
+            true
+          );
+          return true;
+        }
+      );
+      assert.throws(
+        () => validatePrTitle("feat(api):add new feature"),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("A space MUST follow the terminal colon"),
+            true
+          );
+          return true;
+        }
+      );
+    });
+
+    it("should throw when breaking change indicator is incorrectly placed", () => {
+      assert.throws(
+        () => validatePrTitle("feat(!): add new feature"),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("not inside the scope"),
+            true
+          );
+          return true;
+        }
+      );
+    });
+
+    it("should throw for missing descriptions", () => {
+      assert.throws(
+        () => validatePrTitle("feat: "),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("The title must follow the pattern"),
+            true
+          );
+          return true;
+        }
+      );
+    });
+
+    it("should throw for completely malformed titles", () => {
+      assert.throws(
+        () => validatePrTitle("Add new feature"),
+        (err: Error) => {
+          assert.strictEqual(
+            err.message.includes("The type must be one of:"),
+            true
+          );
+          return true;
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for `validatePrTitle` addressed using `node:test` and `node:assert`.
📊 **Coverage:** Happy paths for conventionally accepted PR titles with types, optional scopes, breaking changes, as well as failure paths with descriptive assertions are covered. 
✨ **Result:** A significant improvement in test coverage for pull request title validations.

---
*PR created automatically by Jules for task [14316847467919077644](https://jules.google.com/task/14316847467919077644) started by @beingminimal*