### PR TITLE
🧹 [code health improvement] remove any type in pr-checks.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1339,7 +1338,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1814,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/src/checks/pr-checks.ts
+++ b/src/checks/pr-checks.ts
@@ -45,6 +45,16 @@ export function validatePrTitle(title: string): void {
   }
 }
 
+interface GitHubEvent {
+  pull_request?: {
+    title?: string;
+    number?: number;
+  };
+  repository?: {
+    full_name?: string;
+  };
+}
+
 /**
  * Reads the PR title from the GitHub event file and validates it.
  * This is intended to be used in GitHub Actions.
@@ -77,9 +87,9 @@ export async function checkPrTitleFromEvent(
     }
   }
 
-  let event: any;
+  let event: GitHubEvent;
   try {
-    event = JSON.parse(content);
+    event = JSON.parse(content) as GitHubEvent;
   } catch (error: unknown) {
     throw new Error(
       `Failed to parse GitHub event file: ${


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type for the parsed GitHub event object with a strongly typed `GitHubEvent` interface in `src/checks/pr-checks.ts`.\n💡 **Why:** This improves the maintainability and readability of the codebase by providing strict type checking for the event payload, preventing accidental property access errors.\n✅ **Verification:** Re-ran `npm run build` after changes and confirmed successful compilation.\n✨ **Result:** Improved type safety for `event` object handling without any functional changes to PR title checks.\n\nFixes #1

---
*PR created automatically by Jules for task [3009058787271332681](https://jules.google.com/task/3009058787271332681) started by @beingminimal*