### PR TITLE
🔒 fix: prevent command injection in readBaseBranchPackageJson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1339,7 +1338,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1814,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -190,12 +190,14 @@ export async function readBaseBranchPackageJson(
     .container()
     .from("alpine/git:latest")
     .withSecretVariable("GITHUB_TOKEN", githubToken)
+    .withEnvVariable("REPO_OWNER", repoOwner)
+    .withEnvVariable("REPO_NAME", repoName)
     .withExec([
       "sh",
       "-c",
       [
         "set -eu",
-        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/${repoOwner}/${repoName}.git"`,
+        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/${"${REPO_OWNER}"}/${"${REPO_NAME}"}.git"`,
         `git clone --branch ${shellQuote(branch)} --single-branch --no-checkout --depth=1 "$repo_url" ${shellQuote(repoRoot)}`,
         `cd ${shellQuote(repoRoot)}`,
         `git show HEAD:${shellQuote(filePath)} > /tmp/package.json`,


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `readBaseBranchPackageJson` where `repoOwner` and `repoName` were concatenated into the shell string without sanitization.
⚠️ **Risk:** An attacker could potentially inject arbitrary shell commands by crafting malicious repository owner or name strings.
🛡️ **Solution:** Replaced string interpolation with Dagger's `withEnvVariable()`, securely passing `repoOwner` and `repoName` as environment variables which are safely read by the shell script.

---
*PR created automatically by Jules for task [17344783766719402793](https://jules.google.com/task/17344783766719402793) started by @beingminimal*