### PR TITLE
🔒 fix(publish): prevent command injection in readBaseBranchPackageJson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1339,7 +1338,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1814,7 +1812,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }

--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -195,7 +195,9 @@ export async function readBaseBranchPackageJson(
       "-c",
       [
         "set -eu",
-        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/${repoOwner}/${repoName}.git"`,
+        `repo_owner=${shellQuote(repoOwner)}`,
+        `repo_name=${shellQuote(repoName)}`,
+        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/$repo_owner/$repo_name.git"`,
         `git clone --branch ${shellQuote(branch)} --single-branch --no-checkout --depth=1 "$repo_url" ${shellQuote(repoRoot)}`,
         `cd ${shellQuote(repoRoot)}`,
         `git show HEAD:${shellQuote(filePath)} > /tmp/package.json`,


### PR DESCRIPTION
🎯 **What:** The `readBaseBranchPackageJson` helper in `src/publish/helpers.ts` directly interpolated `repoOwner` and `repoName` into a shell command without escaping them.
⚠️ **Risk:** A malicious repository name or owner could lead to command injection when executed in the shell inside the container.
🛡️ **Solution:** `repoOwner` and `repoName` are now properly escaped using `shellQuote()` and assigned to safe shell variables before being interpolated into the `repo_url` variable assignment.

Fixes #1

---
*PR created automatically by Jules for task [4109010971960407559](https://jules.google.com/task/4109010971960407559) started by @beingminimal*