### PR TITLE
🔒 fix: prevent command injection in repository URL construction

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -195,7 +195,9 @@ export async function readBaseBranchPackageJson(
       "-c",
       [
         "set -eu",
-        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/${repoOwner}/${repoName}.git"`,
+        `repo_owner=${shellQuote(repoOwner)}`,
+        `repo_name=${shellQuote(repoName)}`,
+        `repo_url="https://x-access-token:${"${GITHUB_TOKEN}"}@github.com/$repo_owner/$repo_name.git"`,
         `git clone --branch ${shellQuote(branch)} --single-branch --no-checkout --depth=1 "$repo_url" ${shellQuote(repoRoot)}`,
         `cd ${shellQuote(repoRoot)}`,
         `git show HEAD:${shellQuote(filePath)} > /tmp/package.json`,


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In `src/publish/helpers.ts`, `repoOwner` and `repoName` (TypeScript variables) were directly interpolated into a double-quoted shell string for the execution of a dynamic shell script via Dagger's `withExec`. This allowed command execution if the interpolated string contained backticks or `$()`.

⚠️ **Risk:** The potential impact if left unfixed
An attacker supplying malicious values for the repository name or owner could execute arbitrary shell commands inside the container during execution.

🛡️ **Solution:** How the fix addresses the vulnerability
Following the secure pattern already present in `src/publish/index.ts`, I safely shell-quoted `repoOwner` and `repoName` using the `shellQuote()` utility function, and assigned them to bash variables (`repo_owner` and `repo_name`) inside the script. The script then safely uses these variables inside the URL constructor, negating any chance of command injection from the inputs.

---
*PR created automatically by Jules for task [6021364559655081171](https://jules.google.com/task/6021364559655081171) started by @beingminimal*