### PR TITLE
🧹 refactor(playwright): replace console.log with process.stdout.write

### DIFF
--- a/src/playwright/affected/affected-selectors.runtime.ts
+++ b/src/playwright/affected/affected-selectors.runtime.ts
@@ -338,7 +338,7 @@ function run(): void {
     const affected = listTestsAll ? packageNames : affectedPackages(changed, files, packageNames, reverseGraph);
 
     if (listOnly) {
-      console.log(affected.join(","));
+      process.stdout.write(affected.join(",") + "\n");
       return;
     }
 
@@ -350,7 +350,7 @@ function run(): void {
       }
     }
 
-    console.log(tests.join(" "));
+    process.stdout.write(tests.join(" ") + "\n");
   } catch (error) {
     console.error("❌ Runtime Error:");
     console.error(error instanceof Error ? (error.stack ?? error.message) : error);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of `console.log` for CLI data output.
💡 **Why:** `console.log` can be flagged as a debugging artifact or a code smell by linters and code quality checks. By replacing it with `process.stdout.write(data + "\n")`, we make it clear that standard output is intentional while preserving exactly the same CLI output behavior.
✅ **Verification:** Verified the fix by successfully running `npm run build` locally. The runtime test script's structure is unmodified, simply utilizing the more formal logging process.
✨ **Result:** Improved maintainability by reducing ambiguity about output methods, thus resolving the related warning and meeting clean code expectations. Fixes the issue without modifying lock files or causing side effects.

---
*PR created automatically by Jules for task [15810092434014245687](https://jules.google.com/task/15810092434014245687) started by @beingminimal*