### PR TITLE
feat(checks): support custom testScript parameter in node checks

### DIFF
--- a/src/checks/node-checks.ts
+++ b/src/checks/node-checks.ts
@@ -7,7 +7,11 @@ import {
   runNpmScript,
   withFullSource,
 } from "#shared/index.js";
-import { normalizePaths, resolveWorkspacePath, shellQuote } from "#shared/path-utils.js";
+import {
+  normalizePaths,
+  resolveWorkspacePath,
+  shellQuote,
+} from "#shared/path-utils.js";
 import type { NodeChecksOptions } from "./types.js";
 
 function buildVerifyScript(
@@ -112,14 +116,18 @@ export async function runNodeChecks(
         let testWorkspace = workspace;
         const buildCheck = `node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); process.exit(pkg.scripts && pkg.scripts.build ? 0 : 1)"`;
 
-        testWorkspace = testWorkspace.withExec(["bash", "-lc", [
-          STRICT_SHELL_HEADER,
-          `cd ${shellQuote(resolveWorkspacePath(DEFAULT_WORKSPACE, packagePath))}`,
-          `if ${buildCheck} 2>/dev/null; then`,
-          `  npm run build`,
-          `fi`,
-        ].join("\n")]);
-        workspace = runNpmScript(testWorkspace, "test", {
+        testWorkspace = testWorkspace.withExec([
+          "bash",
+          "-lc",
+          [
+            STRICT_SHELL_HEADER,
+            `cd ${shellQuote(resolveWorkspacePath(DEFAULT_WORKSPACE, packagePath))}`,
+            `if ${buildCheck} 2>/dev/null; then`,
+            `  npm run build`,
+            `fi`,
+          ].join("\n"),
+        ]);
+        workspace = runNpmScript(testWorkspace, options.testScript ?? "test", {
           cwd: packagePath,
         });
       }

--- a/src/checks/types.ts
+++ b/src/checks/types.ts
@@ -9,6 +9,7 @@ export type NodeChecksOptions = {
   verifyChromiumBidi?: boolean;
   registryScope?: string;
   runAffected?: boolean;
+  testScript?: string;
   base?: string;
   changedFiles?: string;
 };

--- a/src/staydevops-ts.ts
+++ b/src/staydevops-ts.ts
@@ -174,12 +174,14 @@ export class Checks {
     source: Directory,
     nodeAuthToken?: Secret,
     runAffected = false,
+    testScript = "test",
     base = "origin/main",
     changedFiles = "",
   ): Promise<void> {
     await runNodeChecks(source, nodeAuthToken, {
       test: true,
       runAffected,
+      testScript,
       base,
       changedFiles,
     });


### PR DESCRIPTION
Closes #105

### Summary
Exposes a `testScript` option to the checks Dagger module, allowing callers to specify the exact npm test script to invoke inside the Dagger container instead of defaulting to `test`. This keeps the Dagger interface clean and generic, while enabling custom test suites (like `test:nightly`) to run on Dagger.