### PR TITLE
ci: enforce 15-minute timeout for workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,7 +15,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.
     permissions:

--- a/.github/workflows/dagger-checks.yml
+++ b/.github/workflows/dagger-checks.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   dagger-validation:
     name: Run Dagger Validation
-    timeout-minutes: 30
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
   pr-checks:
     name: Run PR Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Enforces 15-minute timeout-minutes for standard workflows across daggerverse.