### PR TITLE
perf(checks): remove global staystack CLI installer and optimize npmrc withNewFile

### DIFF
--- a/src/checks/node-checks.ts
+++ b/src/checks/node-checks.ts
@@ -29,23 +29,6 @@ function buildVerifyScript(
   ].join("\n");
 }
 
-function buildInstallGlobalCliScript(packagePaths: string[]): string {
-  const packagePath = packagePaths.length > 0 ? packagePaths[0] : ".";
-  return [
-    STRICT_SHELL_HEADER,
-    `export NPM_CONFIG_USERCONFIG=${shellQuote(resolveWorkspacePath(DEFAULT_WORKSPACE, ".npmrc"))}`,
-    `cd ${shellQuote(resolveWorkspacePath(DEFAULT_WORKSPACE, packagePath))}`,
-    'published="$(npm view @staytunedllp/staystack version 2>/dev/null || echo "0.0.0")"',
-    'installed="$((npm list -g @staytunedllp/staystack --depth=0 --json 2>/dev/null || true) | node -e \'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => { try { const parsed = JSON.parse(input); process.stdout.write(parsed.dependencies?.["@staytunedllp/staystack"]?.version ?? ""); } catch {} });\')"',
-    'if node -e \'const [installed, published] = process.argv.slice(1); const parts = (value) => value.split(".").map((part) => Number.parseInt(part, 10) || 0); const older = (a, b) => { const av = parts(a); const bv = parts(b); for (let index = 0; index < Math.max(av.length, bv.length); index += 1) { if ((av[index] ?? 0) < (bv[index] ?? 0)) return true; if ((av[index] ?? 0) > (bv[index] ?? 0)) return false; } return false; }; process.exit(installed && !older(installed, published) ? 0 : 1);\' "$installed" "$published"; then',
-    '  echo "staystack CLI ${installed} is current."',
-    "else",
-    '  echo "Installing staystack CLI ${published}."',
-    "  npm install -g @staytunedllp/staystack@latest",
-    "fi",
-  ].join("\n");
-}
-
 function buildRunAffectedTestScript(
   packagePath: string,
   testScript = "test:incremental",
@@ -84,14 +67,6 @@ export async function runNodeChecks(
       "bash",
       "-lc",
       buildVerifyScript(packagePaths, true),
-    ]);
-  }
-
-  if (options.runAffected) {
-    installed = installed.withExec([
-      "bash",
-      "-lc",
-      buildInstallGlobalCliScript(packagePaths),
     ]);
   }
 

--- a/src/shared/npm.ts
+++ b/src/shared/npm.ts
@@ -65,29 +65,21 @@ export function withNpmAuth(
   const registryScope = options.registryScope ?? DEFAULT_REGISTRY_SCOPE;
   const npmrcPaths = normalizePaths(options.npmrcPaths);
 
-  return container
-    .withSecretVariable("NODE_AUTH_TOKEN", nodeAuthToken)
-    .withExec([
-      "bash",
-      "-lc",
-      [
-        STRICT_SHELL_HEADER,
-        "cat > /tmp/staytuned.npmrc <<'EOF'",
-        `@${registryScope}:registry=https://npm.pkg.github.com`,
-        "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}",
-        "legacy-peer-deps=true",
-        "EOF",
-        `for path in $(printf '%s' ${JSON.stringify(npmrcPaths.join(","))} | tr ',' ' '); do`,
-        "  target=\"${path}\"",
-        "  if [ \"${target}\" = \".\" ]; then",
-        `    cp /tmp/staytuned.npmrc ${shellQuote(workspace)}/.npmrc`,
-        "  else",
-        `    mkdir -p ${shellQuote(workspace)}/\"\${target}\"`,
-        `    cp /tmp/staytuned.npmrc ${shellQuote(workspace)}/\"\${target}\"/.npmrc`,
-        "  fi",
-        "done",
-      ].join("\n"),
-    ]);
+  const npmrcContent = [
+    `@${registryScope}:registry=https://npm.pkg.github.com`,
+    "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}",
+    "legacy-peer-deps=true",
+    "",
+  ].join("\n");
+
+  let result = container.withSecretVariable("NODE_AUTH_TOKEN", nodeAuthToken);
+  for (const path of npmrcPaths) {
+    const targetPath =
+      path === "." ? `${workspace}/.npmrc` : `${workspace}/${path}/.npmrc`;
+    result = result.withNewFile(targetPath, npmrcContent);
+  }
+
+  return result;
 }
 
 export function withLockfilesOnly(


### PR DESCRIPTION
Remove unnecessary global CLI install script and convert npmrc setup to native container.withNewFile to eliminate extra bash withExec executions and network delays.