### PR TITLE
fix(publish): pass --legacy-peer-deps to npm ci in publishRelease

### DIFF
--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -257,7 +257,7 @@ async function publishRelease(
   });
   container = withInstalledDependencies(container, packagePath, {
     workspace: DEFAULT_WORKSPACE,
-    npmCiArgs: ["--workspaces=false"],
+    npmCiArgs: ["--workspaces=false", "--legacy-peer-deps"],
   });
   // Reapply npm auth after copying the full source in case the repository ships its own .npmrc.
   container = withFullSource(container, options.source, {


### PR DESCRIPTION
Fixes ERESOLVE peer dependency resolution error during publish release.