### PR TITLE
perf(container): set NODE_OPTIONS max-old-space-size=4096 to prevent exit code 137 OOM kills

### DIFF
--- a/src/shared/container.ts
+++ b/src/shared/container.ts
@@ -18,7 +18,8 @@ export function createBaseNodeContainer(
     .container()
     .from(options.image ?? DEFAULT_IMAGE)
     .withWorkdir(workspace)
-    .withEnvVariable("HUSKY", "0");
+    .withEnvVariable("HUSKY", "0")
+    .withEnvVariable("NODE_OPTIONS", "--max-old-space-size=4096");
 }
 
 export function withMountedCache(


### PR DESCRIPTION
Sets NODE_OPTIONS=--max-old-space-size=4096 in base Node container to prevent Linux OOM killer from killing parallel check processes.