### PR TITLE
chore(dagger): pin the base image with a lockfile

### DIFF
--- a/dagger.lock
+++ b/dagger.lock
@@ -1,0 +1,2 @@
+[["version","1"]]
+["","container.from",["docker.io/library/node:24-bookworm","linux/arm64"],"sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059","pin"]


### PR DESCRIPTION
## Why

daggerverse had **no `dagger.lock`**. `dagger.json` declares no dependencies, so it looked like there was nothing to lock — but the code does `container.from("node:24-bookworm")`, an **unpinned tag**.

Consequences of leaving it unpinned:

- every upstream rebuild of `node:24-bookworm` silently changes the image
- that invalidates the engine cache fleet-wide, which is expensive here (warm run 3m32s vs cold 13m51s)
- behaviour can change with no commit in this repo

## What

Pin the image by digest. The resolved digest is **identical** to the one `staydevops/dagger.lock` already records:

```
sha256:5711a0d445a1af54af9589066c646df387d1831a608226f4cd694fc59e745059
```

So this makes explicit what the adapter was already relying on.

## Platform caveat

The entry is platform-keyed and was generated on `linux/arm64`, matching the Pi 5 runners where the real workload runs.

daggerverse's own checks run on `ubuntu-latest` (x86_64) and pass no `--lock` flag, so they resolve normally and are unaffected. An amd64 entry will be added the first time someone locks on that platform.

Worth considering separately: daggerverse's checks currently validate on an architecture nothing deploys on.

## Verification

```
dagger --lock=frozen -m . check "checks:format-incremental"   → DONE
```