### PR TITLE
chore(release): fast-forward manifest to 1.8.0 for the v1.8.0 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.2.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.2.0",
+      "version": "1.8.0",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.2.0",
+  "version": "1.8.0",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Why

No daggerverse tag can currently be pinned. Every existing tag declares an `engineVersion` other than the one the organisation installs:

| Ref | `engineVersion` |
| --- | --- |
| `v1.4.4` and earlier | `v0.20.3` |
| `v1.6.1` – `v1.7.0` | `v0.21.7` |
| `main` | `v1.0.0-beta.7` |

Workflows install `v1.0.0-beta.7` from `staydevops/.github/dagger-version`, so pinning any current tag fails with `module requires dagger X, but you have Y`. That is why `staydevops` `nightly.yml` and `release-reusable.yml` still float on `@main` — it is the only ref that loads. The floating refs are load-bearing, not sloppiness.

Separately, the manifest reads `1.2.0` while tags reach `v1.7.0`, and the two have never agreed: the `v1.2.0` tag points at a commit whose manifest read `1.0.5`.

## What

`package.json` and `package-lock.json` go to `1.8.0`. Nothing else changes.

After merge, tag `v1.8.0` on the merge commit — the first daggerverse tag declaring `v1.0.0-beta.7`, and the point where manifest and tag start agreeing.

Minor rather than patch: the engine crosses `v0.21.7` to `v1.0.0-beta.7`, and the Workspace refactor changed the module constructor, so `dagger call` consumers are affected.

## Release shape

Daggerverse is distributed as a public git ref — `daggerverse.dev` indexes modules from tags (it currently resolves this module at `700c093`, which is `v1.7.0`), and `dagger v1.0.0-beta.7` exposes no `publish` subcommand. The tag *is* the release artifact; no package is published.

## Unblocks

- `StaytunedLLP/staydevops#739` — pinning `@main` → `@v1.8.0`
- `StaytunedLLP/staydevops#703` — the post-merge release pipeline

Not included: `app-hosting-reusable.yml` still pins `v1.4.4`, where the module had no constructor. Moving it is an API migration needing a real deploy test, not a version bump.

Closes #149