### PR TITLE
feat(release): add idempotent hourly release actions

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -7,7 +7,7 @@ import { shellQuote } from "#shared/path-utils.js";
 const EXACT_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const REGISTRY_SCOPE_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 
-function packageFilePath(packagePath: string, fileName: string): string {
+export function packageFilePath(packagePath: string, fileName: string): string {
   if (packagePath === "." || packagePath.length === 0) {
     return fileName;
   }
@@ -268,4 +268,112 @@ export async function checkRegistryVersion(
   return (
     parsed === version || (Array.isArray(parsed) && parsed.includes(version))
   );
+}
+
+/**
+ * Runs a gh CLI command against the repository and returns its trimmed stdout.
+ *
+ * Release state lives in four places -- manifest, tag, GitHub Release, and
+ * registry -- and the hourly flow has to read three of them before deciding
+ * what to do. Going through gh rather than raw curl keeps the auth handling in
+ * one place and gives useful errors instead of a JSON blob.
+ */
+async function ghQuery(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  args: string,
+): Promise<string> {
+  const output = await dag
+    .container()
+    .from("alpine/git:latest")
+    .withExec(["sh", "-c", "apk add --no-cache github-cli >/dev/null 2>&1"])
+    .withSecretVariable("GITHUB_TOKEN", githubToken)
+    .withEnvVariable("GH_REPO", `${repoOwner}/${repoName}`)
+    .withExec([
+      "sh",
+      "-c",
+      // A missing tag or release is a legitimate answer, not a failure, so the
+      // command must not abort the pipeline when gh exits non-zero.
+      `${args} 2>/dev/null || true`,
+    ])
+    .stdout();
+
+  return output.trim();
+}
+
+/**
+ * Reports whether a git tag already exists on the remote.
+ */
+export async function checkTagExists(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  tagName: string,
+): Promise<boolean> {
+  const out = await ghQuery(
+    githubToken,
+    repoOwner,
+    repoName,
+    `gh api "repos/${repoOwner}/${repoName}/git/ref/tags/${tagName}" --jq .ref`,
+  );
+
+  return out === `refs/tags/${tagName}`;
+}
+
+/**
+ * Reports whether a GitHub Release already exists for a tag.
+ *
+ * Distinct from the tag existing: a tag with no Release is the repair case the
+ * release flow must handle rather than fail on.
+ */
+export async function checkReleaseExists(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  tagName: string,
+): Promise<boolean> {
+  const out = await ghQuery(
+    githubToken,
+    repoOwner,
+    repoName,
+    `gh api "repos/${repoOwner}/${repoName}/releases/tags/${tagName}" --jq .tag_name`,
+  );
+
+  return out === tagName;
+}
+
+/**
+ * Creates a GitHub Release for an existing tag.
+ *
+ * `--verify-tag` refuses to invent a tag that does not exist, which turns a
+ * silent mistake into an error, and `--generate-notes` replaces the hand-rolled
+ * release body the workflow used to assemble.
+ */
+export async function createGithubRelease(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  tagName: string,
+  previousTag?: string,
+): Promise<void> {
+  const notesStart = previousTag
+    ? ` --notes-start-tag ${shellQuote(previousTag)}`
+    : "";
+
+  await dag
+    .container()
+    .from("alpine/git:latest")
+    .withExec(["sh", "-c", "apk add --no-cache github-cli >/dev/null 2>&1"])
+    .withSecretVariable("GITHUB_TOKEN", githubToken)
+    .withEnvVariable("GH_REPO", `${repoOwner}/${repoName}`)
+    .withExec([
+      "sh",
+      "-c",
+      [
+        "set -eu",
+        `gh release create ${shellQuote(tagName)} --verify-tag --generate-notes --title ${shellQuote(tagName)}${notesStart}`,
+      ].join("\n"),
+    ])
+    .sync();
 }

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -2,8 +2,12 @@ import path from "node:path";
 import { Directory, Secret, dag } from "@dagger.io/dagger";
 import {
   checkRegistryVersion,
+  checkReleaseExists,
+  checkTagExists,
+  createGithubRelease,
   ensureFileExistsAtPath,
   extractScope,
+  packageFilePath,
   compareVersions,
   nextPatchVersion,
   parseExactVersion,
@@ -15,6 +19,8 @@ import {
   ReleasePackageOptions,
   ReleasePackageResult,
   PublishPackageResult,
+  PrepareHourlyReleaseResult,
+  GithubOnlyReleaseResult,
   SyncPrVersionResult,
 } from "./types.js";
 import {
@@ -231,17 +237,81 @@ async function publishRelease(
   await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
   parseExactVersion(manifest.version);
 
-  if (
-    await checkRegistryVersion(
+  const tagName = `v${manifest.version}`;
+
+  // Read all three surfaces before touching any of them. An hourly schedule
+  // re-runs against state it may have already produced, and the four
+  // combinations below are not equally safe: three are recoverable, one means
+  // a human has to look.
+  const [inRegistry, tagExists, releaseExists] = await Promise.all([
+    checkRegistryVersion(
       manifest.name,
       manifest.version,
       options.githubToken,
       registryScope,
-    )
-  ) {
+    ),
+    checkTagExists(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      tagName,
+    ),
+    checkReleaseExists(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      tagName,
+    ),
+  ]);
+
+  // A tag without the package means a publish died between the two steps.
+  // Re-running would push a package under a tag that already names a
+  // different tree, so stop and say exactly which surfaces disagree.
+  if (tagExists && !inRegistry) {
     throw new Error(
-      `Version "${manifest.version}" of package "${manifest.name}" already exists in the registry.`,
+      `Partial release state for "${manifest.name}@${manifest.version}": ` +
+        `tag "${tagName}" exists but the package is absent from the registry. ` +
+        "Resolve by hand -- either publish the package for that tag or delete " +
+        "the tag if the release was abandoned.",
     );
+  }
+
+  // Everything already present. Success, not a failure: this is what an
+  // unchanged hourly run looks like.
+  if (inRegistry && tagExists && releaseExists) {
+    return {
+      action: "publish",
+      packageName: manifest.name,
+      publishedVersion: manifest.version,
+      tagged: true,
+      tagName,
+      registryPublished: false,
+      releaseCreated: false,
+      noop: true,
+    };
+  }
+
+  // Package and tag exist but the Release is missing -- repair it without
+  // republishing. This is the state the workflow's old raw-curl release call
+  // left behind whenever it failed after a successful publish.
+  if (inRegistry && tagExists && !releaseExists) {
+    await createGithubRelease(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      tagName,
+    );
+
+    return {
+      action: "publish",
+      packageName: manifest.name,
+      publishedVersion: manifest.version,
+      tagged: true,
+      tagName,
+      registryPublished: false,
+      releaseCreated: true,
+      noop: false,
+    };
   }
 
   let container = createBaseNodeContainer();
@@ -295,7 +365,16 @@ async function publishRelease(
   ]);
 
   await container.sync();
-  const tagName = await pushReleaseTag(options, manifest.version);
+
+  // tagExists is false here: the only path that reaches this point with a tag
+  // already present threw above as a partial state.
+  await pushReleaseTag(options, manifest.version);
+  await createGithubRelease(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    tagName,
+  );
 
   return {
     action: "publish",
@@ -303,19 +382,183 @@ async function publishRelease(
     publishedVersion: manifest.version,
     tagged: true,
     tagName,
+    registryPublished: true,
+    releaseCreated: true,
+    noop: false,
   };
 }
 
 /**
- * Production release pipeline with PR version synchronization and main-only publishing.
+ * Computes the next release without touching anything remote.
+ *
+ * Deliberately side-effect free: it returns the version and the manifest
+ * content to commit, and the caller creates the pull request. Keeping the
+ * mutation in the workflow means a dry run is genuinely dry, and it keeps this
+ * function cheap enough to call on an hourly schedule that mostly finds
+ * nothing to do.
+ */
+async function prepareHourlyRelease(
+  options: ReleasePackageOptions,
+): Promise<PrepareHourlyReleaseResult> {
+  const packagePath = options.packagePath ?? ".";
+  const manifest = await readPackageJsonAtPath(options.source, packagePath);
+
+  // Reject a non-exact version before computing anything from it. A range or
+  // prerelease here would produce a nonsense tag.
+  parseExactVersion(manifest.version);
+  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+
+  const nextVersion = nextPatchVersion(manifest.version);
+  const tagName = `v${nextVersion}`;
+
+  // If the tag this run would produce already exists, the previous hour's
+  // release landed and nothing new has been merged since.
+  const alreadyReleased = await checkTagExists(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    tagName,
+  );
+
+  if (alreadyReleased) {
+    return {
+      action: "prepare-hourly-release",
+      packageName: manifest.name,
+      currentVersion: manifest.version,
+      nextVersion,
+      tagName,
+      releaseNeeded: false,
+      reason: `Tag ${tagName} already exists; nothing to release.`,
+    };
+  }
+
+  const manifestFile = packageFilePath(packagePath, "package.json");
+  const lockFile = packageFilePath(packagePath, "package-lock.json");
+
+  const manifestJson = JSON.parse(
+    await options.source.file(manifestFile).contents(),
+  );
+  manifestJson.version = nextVersion;
+
+  const lockJson = JSON.parse(await options.source.file(lockFile).contents());
+  lockJson.version = nextVersion;
+  if (lockJson.packages?.[""]) {
+    // npm keeps the version in two places and a mismatch makes `npm ci` refuse
+    // to install, so both move together.
+    lockJson.packages[""].version = nextVersion;
+  }
+
+  return {
+    action: "prepare-hourly-release",
+    packageName: manifest.name,
+    currentVersion: manifest.version,
+    nextVersion,
+    tagName,
+    releaseNeeded: true,
+    reason: `Next patch release ${nextVersion}.`,
+    manifestContent: `${JSON.stringify(manifestJson, null, 2)}\n`,
+    lockfileContent: `${JSON.stringify(lockJson, null, 2)}\n`,
+  };
+}
+
+/**
+ * Tags and creates a GitHub Release without publishing a package.
+ *
+ * For repositories whose release artifact is not a package: a private
+ * application, or a Dagger module where the public git tag is itself the
+ * distribution mechanism and no publish command exists.
+ */
+async function githubOnlyRelease(
+  options: ReleasePackageOptions,
+): Promise<GithubOnlyReleaseResult> {
+  const packagePath = options.packagePath ?? ".";
+  const manifest = await readPackageJsonAtPath(options.source, packagePath);
+
+  parseExactVersion(manifest.version);
+
+  const tagName = `v${manifest.version}`;
+
+  const [tagExists, releaseExists] = await Promise.all([
+    checkTagExists(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      tagName,
+    ),
+    checkReleaseExists(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      tagName,
+    ),
+  ]);
+
+  if (tagExists && releaseExists) {
+    return {
+      action: "github-only",
+      version: manifest.version,
+      tagName,
+      tagCreated: false,
+      releaseCreated: false,
+      noop: true,
+    };
+  }
+
+  if (!tagExists) {
+    await pushReleaseTag(options, manifest.version);
+  }
+
+  // Reached when the tag existed but its Release did not -- the repair case.
+  await createGithubRelease(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    tagName,
+  );
+
+  return {
+    action: "github-only",
+    version: manifest.version,
+    tagName,
+    tagCreated: !tagExists,
+    releaseCreated: true,
+    noop: false,
+  };
+}
+
+/**
+ * Production release pipeline.
+ *
+ * `prepare-hourly-release` computes and returns; `publish` and `github-only`
+ * mutate remote state and are idempotent, so an hourly schedule can re-run
+ * them safely.
  */
 export async function releasePackage(
   options: ReleasePackageOptions,
 ): Promise<string> {
-  const result =
-    options.action === "sync-pr-version"
-      ? await syncPrVersion(options)
-      : await publishRelease(options);
+  let result: ReleasePackageResult;
+
+  switch (options.action) {
+    case "sync-pr-version":
+      result = await syncPrVersion(options);
+      break;
+    case "prepare-hourly-release":
+      result = await prepareHourlyRelease(options);
+      break;
+    case "github-only":
+      result = await githubOnlyRelease(options);
+      break;
+    case "publish":
+      result = await publishRelease(options);
+      break;
+    default:
+      // An unknown action used to fall through to publish, which is the most
+      // destructive branch. Fail instead.
+      throw new Error(
+        `Unknown release action "${options.action}". Expected one of: ` +
+          "sync-pr-version, prepare-hourly-release, publish, github-only.",
+      );
+  }
 
   return serializeResult(result);
 }

--- a/src/publish/types.ts
+++ b/src/publish/types.ts
@@ -1,6 +1,10 @@
 import { Directory, Secret } from "@dagger.io/dagger";
 
-export type ReleasePackageAction = "sync-pr-version" | "publish";
+export type ReleasePackageAction =
+  | "sync-pr-version"
+  | "publish"
+  | "prepare-hourly-release"
+  | "github-only";
 
 export interface ReleasePackageOptions {
   /**
@@ -82,8 +86,48 @@ export interface PublishPackageResult {
   publishedVersion: string;
   tagged: boolean;
   tagName?: string;
+  /**
+   * What each surface required. An hourly job re-runs against state it may
+   * have already produced, so the caller needs to distinguish "did the work"
+   * from "found it already done" -- both are success.
+   */
+  registryPublished: boolean;
+  releaseCreated: boolean;
+  noop: boolean;
+}
+
+export interface PrepareHourlyReleaseResult {
+  action: "prepare-hourly-release";
+  packageName: string;
+  currentVersion: string;
+  nextVersion: string;
+  tagName: string;
+  /**
+   * False when nothing has landed since the last tag, which is the common
+   * case for an hourly schedule and must exit successfully rather than open
+   * an empty release pull request.
+   */
+  releaseNeeded: boolean;
+  reason: string;
+  /**
+   * The manifest content the caller should commit. Returned rather than
+   * written so this action stays free of remote side effects.
+   */
+  manifestContent?: string;
+  lockfileContent?: string;
+}
+
+export interface GithubOnlyReleaseResult {
+  action: "github-only";
+  version: string;
+  tagName: string;
+  tagCreated: boolean;
+  releaseCreated: boolean;
+  noop: boolean;
 }
 
 export type ReleasePackageResult =
   | SyncPrVersionResult
-  | PublishPackageResult;
+  | PublishPackageResult
+  | PrepareHourlyReleaseResult
+  | GithubOnlyReleaseResult;

--- a/src/staydevops-ts.ts
+++ b/src/staydevops-ts.ts
@@ -25,6 +25,7 @@ import {
   gitDiffStaged,
 } from "#git/index.js";
 import { releasePackage } from "#publish/index.js";
+import type { ReleasePackageAction } from "#publish/types.js";
 import { runPlaywrightTests } from "#playwright/index.js";
 
 const DEFAULT_CHECK_WORKSPACE_EXCLUDES = [
@@ -725,8 +726,17 @@ export class StaydevopsTs {
    * ahead of the latest base branch patch version without overwriting manual major/minor bumps.
    * When a bump is needed, the function commits and pushes the update back to the PR branch.
    *
-   * Use `publish` on the main branch to validate the canonical package version, detect registry
-   * conflicts, publish the package, and push the release tag.
+   * Use `prepare-hourly-release` to compute the next patch version and return the manifest and
+   * lockfile content to commit. It creates nothing and pushes nothing, so a dry run is genuinely
+   * dry and the caller owns the pull request.
+   *
+   * Use `publish` on the main branch to publish the package, push the tag, and create the GitHub
+   * Release. It is idempotent: an already-published version with its tag and Release is a
+   * successful no-op, a missing Release is repaired without republishing, and a tag whose package
+   * is absent fails loudly because that means a previous publish died midway.
+   *
+   * Use `github-only` where the release artifact is not a package -- a private application, or a
+   * Dagger module whose public git tag is itself the distribution mechanism.
    *
    * This flow assumes branch protection requires pull requests to be up to date before merging.
    *
@@ -756,14 +766,21 @@ export class StaydevopsTs {
     packagePath?: string,
     prBranch?: string,
   ): Promise<string> {
-    if (action !== "sync-pr-version" && action !== "publish") {
+    const supported = [
+      "sync-pr-version",
+      "prepare-hourly-release",
+      "publish",
+      "github-only",
+    ] as const;
+
+    if (!supported.includes(action as (typeof supported)[number])) {
       throw new Error(
-        `Unsupported release action "${action}". Expected "sync-pr-version" or "publish".`,
+        `Unsupported release action "${action}". Expected one of: ${supported.join(", ")}.`,
       );
     }
 
     return releasePackage({
-      action,
+      action: action as ReleasePackageAction,
       source,
       githubToken,
       repoOwner,


### PR DESCRIPTION
## Why

The plan specifies an idempotency matrix for `publish` that the code did not implement. Three gaps, each of which breaks the **second** run of an hourly schedule:

| Gap | Before | After |
| --- | --- | --- |
| Version already in registry | **threw an error** | successful no-op |
| Tag already exists | `git tag -a` fails, "already exists" | checked first, skipped |
| GitHub Release | **never created** — workflow used raw `curl` | `gh release create --verify-tag --generate-notes` |

The first matters most: an hourly job re-running against its own output would have gone red every hour after the first successful release.

## `publish` — the four states

Reads registry, tag, and Release before touching any of them:

| Registry | Tag | Release | Outcome |
| --- | --- | --- | --- |
| ✓ | ✓ | ✓ | successful no-op |
| ✓ | ✓ | ✗ | repair the Release, no republish |
| ✗ | ✓ | — | **fail loudly** — publish died midway |
| ✗ | ✗ | — | publish, tag, release |

The third case names both surfaces in the error. Re-running there would tag a tree different from the one already published, so it needs a human.

## `prepare-hourly-release`

Deliberately free of remote side effects: returns the next version plus manifest and lockfile content, and the caller commits. That makes `dry_run` genuinely dry, and keeps it cheap for a schedule that mostly finds nothing to do.

It writes the version to **both** places npm keeps it in the lockfile — a mismatch there makes `npm ci` refuse to install.

## `github-only`

Tags and releases without publishing: for a private application, or a Dagger module whose public tag is itself the distribution mechanism and where no publish command exists.

## Also

Unknown actions previously fell through to `publish` — the most destructive branch — so a typo would have published. They now throw.

Results carry `registryPublished` / `releaseCreated` / `noop`, so a caller can distinguish work done from work already present. Both are success; only one belongs in a release summary.

## Verification

- `tsc` build passes.
- `dagger -m . functions` loads the module: `client-version=v1.0.0-beta.7 server-version=v1.0.0-beta.7`, type definitions resolved, `release-package` present.
- `lint`, `format:check`, and `test` pass — but they are `echo` no-ops in this repo, so they prove nothing. Flagged below.

## Worth a separate issue

**daggerverse has no lint, no format check, and no tests** — all three scripts are `echo`. Its `dagger check` is effectively build-only, for the module four other repositories load.

Closes #151