### PR TITLE
chore(release): bump manifest to 1.9.0 for the v1.9.0 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Why

#152 is merged but **unreachable**. Every caller pins `daggerverse@v1.8.0`, which predates it, so the idempotent `publish`, `prepare-hourly-release`, and `github-only` are not in use anywhere.

The cost showed up within the hour. staystack's `1.8.77` publish ran the old code:

```
! [rejected]        v1.8.77 -> v1.8.77 (already exists)
```

npm publish succeeded, then the tag push failed because the tag pre-existed — and no GitHub Release was created. Under #152 that run reads registry, tag, and Release first, stops before publishing when they disagree, and repairs a missing Release without republishing.

## What

`package.json` and `package-lock.json` → `1.9.0`. Nothing else.

After merge: tag `v1.9.0`, then move the `staydevops` pins from `@v1.8.0`.

Minor rather than patch — three new public actions, no breaking change to existing callers.

## Verification

- Only version lines changed (3 lines across 2 files).
- `tsc` build passes at the new version.
- `main` confirmed to contain the #152 actions before branching.

Closes #153