### PR TITLE
feat(release): move the hourly release cycle into the module

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -377,3 +377,167 @@ export async function createGithubRelease(
     ])
     .sync();
 }
+
+/**
+ * Base container for gh operations that must succeed.
+ *
+ * Separate from ghQuery: that one swallows failures because a missing tag is a
+ * legitimate answer. Anything that mutates has to surface its error instead.
+ */
+function ghContainer(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+) {
+  return dag
+    .container()
+    .from("alpine/git:latest")
+    .withExec(["sh", "-c", "apk add --no-cache github-cli jq >/dev/null 2>&1"])
+    .withSecretVariable("GITHUB_TOKEN", githubToken)
+    .withEnvVariable("GH_REPO", `${repoOwner}/${repoName}`);
+}
+
+export interface OpenReleasePr {
+  number: number;
+  url: string;
+  ageHours: number;
+}
+
+/**
+ * Finds an in-flight hourly release pull request, if any.
+ *
+ * The hourly schedule must not open a second release while the first is still
+ * being checked, and it must not treat an indefinitely stuck one as normal --
+ * hence the age, which the caller turns into a failure past a threshold.
+ */
+export async function findOpenReleasePr(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  branchPrefix: string,
+): Promise<OpenReleasePr | undefined> {
+  const out = await ghQuery(
+    githubToken,
+    repoOwner,
+    repoName,
+    `gh pr list --state open --json number,url,createdAt,headRefName ` +
+      `--jq '[.[] | select(.headRefName | startswith("${branchPrefix}"))][0] // empty'`,
+  );
+
+  if (!out) {
+    return undefined;
+  }
+
+  const pr = JSON.parse(out);
+  const ageMs = Date.now() - new Date(pr.createdAt).getTime();
+
+  return {
+    number: pr.number,
+    url: pr.url,
+    ageHours: Math.floor(ageMs / 3_600_000),
+  };
+}
+
+/**
+ * Creates a release branch and commits the updated manifest onto it.
+ *
+ * Uses createCommitOnBranch rather than `git commit && git push` so the commit
+ * is signed by GitHub. The staycore ruleset requires signatures; it currently
+ * targets only the default branch, so an unsigned commit on a release branch
+ * happens to pass today. Depending on that would break the release flow with an
+ * opaque signature error the day the ruleset widens.
+ */
+export async function createReleaseBranchWithCommit(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  branch: string,
+  baseBranch: string,
+  message: string,
+  files: { path: string; contents: string }[],
+): Promise<string> {
+  const additions = files
+    .map(
+      (f) =>
+        `{ path: ${JSON.stringify(f.path)}, contents: $c${files.indexOf(f)} }`,
+    )
+    .join(", ");
+
+  const varDecls = files
+    .map((_, i) => `$c${i}: Base64String!`)
+    .join(", ");
+
+  const fileWrites = files
+    .map(
+      (f, i) =>
+        `printf '%s' ${shellQuote(f.contents)} | base64 | tr -d '\\n' > /tmp/c${i}`,
+    )
+    .join("\n");
+
+  const fileFlags = files.map((_, i) => `-F c${i}=@/tmp/c${i}`).join(" ");
+
+  const output = await ghContainer(githubToken, repoOwner, repoName)
+    .withExec([
+      "sh",
+      "-c",
+      [
+        "set -eu",
+        `head_oid="$(gh api "repos/${repoOwner}/${repoName}/git/ref/heads/${baseBranch}" --jq .object.sha)"`,
+        `gh api "repos/${repoOwner}/${repoName}/git/refs" -f ref=${shellQuote(`refs/heads/${branch}`)} -f sha="$head_oid" >/dev/null`,
+        fileWrites,
+        `query='mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $message: String!, ${varDecls}) { createCommitOnBranch(input: { branch: { repositoryNameWithOwner: $repo, branchName: $branch }, message: { headline: $message }, expectedHeadOid: $oid, fileChanges: { additions: [ ${additions} ] } }) { commit { oid } } }'`,
+        `gh api graphql -f query="$query" -F repo=${shellQuote(`${repoOwner}/${repoName}`)} -F branch=${shellQuote(branch)} -F oid="$head_oid" -F message=${shellQuote(message)} ${fileFlags} --jq '.data.createCommitOnBranch.commit.oid'`,
+      ].join("\n"),
+    ])
+    .stdout();
+
+  return output.trim();
+}
+
+/**
+ * Opens the release pull request and returns its URL.
+ */
+export async function createReleasePr(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  branch: string,
+  baseBranch: string,
+  title: string,
+  body: string,
+): Promise<string> {
+  const output = await ghContainer(githubToken, repoOwner, repoName)
+    .withExec([
+      "sh",
+      "-c",
+      [
+        "set -eu",
+        `gh pr create --base ${shellQuote(baseBranch)} --head ${shellQuote(branch)} --title ${shellQuote(title)} --body ${shellQuote(body)}`,
+      ].join("\n"),
+    ])
+    .stdout();
+
+  return output.trim().split("\n").pop() ?? "";
+}
+
+/**
+ * Asks GitHub to merge the release pull request once its required checks pass.
+ *
+ * Auto-merge does not bypass protection. Where a ruleset requires a code-owner
+ * review the request simply waits, which is why the caller reports the URL
+ * rather than assuming the merge happened.
+ */
+export async function enableAutoMerge(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  prUrl: string,
+): Promise<void> {
+  await ghContainer(githubToken, repoOwner, repoName)
+    .withExec([
+      "sh",
+      "-c",
+      ["set -eu", `gh pr merge ${shellQuote(prUrl)} --auto --squash`].join("\n"),
+    ])
+    .sync();
+}

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -5,6 +5,10 @@ import {
   checkReleaseExists,
   checkTagExists,
   createGithubRelease,
+  createReleaseBranchWithCommit,
+  createReleasePr,
+  enableAutoMerge,
+  findOpenReleasePr,
   ensureFileExistsAtPath,
   extractScope,
   packageFilePath,
@@ -20,6 +24,7 @@ import {
   ReleasePackageResult,
   PublishPackageResult,
   PrepareHourlyReleaseResult,
+  HourlyReleaseResult,
   GithubOnlyReleaseResult,
   SyncPrVersionResult,
 } from "./types.js";
@@ -461,6 +466,166 @@ async function prepareHourlyRelease(
   };
 }
 
+const RELEASE_BRANCH_PREFIX = "release/hourly-";
+
+/**
+ * The whole hourly cycle, in containers.
+ *
+ * This deliberately lives in the module rather than in workflow shell. The
+ * shared runners carry no `gh` and no `jq` -- a first attempt at driving this
+ * from workflow steps died with `gh: command not found` -- and every host tool
+ * a workflow depends on is another thing that can differ between runners. Here
+ * the runner needs Docker and nothing else, and the flow can be exercised
+ * locally with `dagger call`.
+ */
+async function hourlyRelease(
+  options: ReleasePackageOptions,
+): Promise<HourlyReleaseResult> {
+  const packagePath = options.packagePath ?? ".";
+  const baseBranch = options.baseBranch ?? "main";
+  const staleHours = options.stalePrHours ?? 6;
+  const manifest = await readPackageJsonAtPath(options.source, packagePath);
+
+  parseExactVersion(manifest.version);
+  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+
+  const nextVersion = nextPatchVersion(manifest.version);
+  const tagName = `v${nextVersion}`;
+
+  const base = {
+    action: "hourly-release" as const,
+    packageName: manifest.name,
+    currentVersion: manifest.version,
+    nextVersion,
+    tagName,
+    autoMergeRequested: options.autoMerge ?? true,
+  };
+
+  // A release already in flight. Exiting successfully is correct -- but only
+  // while it is progressing, so an old one becomes a hard failure rather than a
+  // silent halt.
+  const inFlight = await findOpenReleasePr(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    RELEASE_BRANCH_PREFIX,
+  );
+
+  if (inFlight) {
+    if (inFlight.ageHours >= staleHours) {
+      throw new Error(
+        `Release pull request #${inFlight.number} has been open ${inFlight.ageHours}h ` +
+          `(threshold ${staleHours}h): ${inFlight.url}. ` +
+          "Releases are halted until it merges or is closed.",
+      );
+    }
+
+    return {
+      ...base,
+      outcome: "skipped-in-flight",
+      reason: `Release PR #${inFlight.number} is awaiting checks (${inFlight.ageHours}h old).`,
+      prUrl: inFlight.url,
+    };
+  }
+
+  // The tag this run would produce already exists, so the previous release
+  // landed and nothing has been merged since. The common case on an hourly
+  // schedule.
+  const alreadyReleased = await checkTagExists(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    tagName,
+  );
+
+  if (alreadyReleased) {
+    return {
+      ...base,
+      outcome: "nothing-to-release",
+      reason: `Tag ${tagName} already exists; nothing to release.`,
+    };
+  }
+
+  const manifestFile = packageFilePath(packagePath, "package.json");
+  const lockFile = packageFilePath(packagePath, "package-lock.json");
+
+  const manifestJson = JSON.parse(
+    await options.source.file(manifestFile).contents(),
+  );
+  manifestJson.version = nextVersion;
+
+  const lockJson = JSON.parse(await options.source.file(lockFile).contents());
+  lockJson.version = nextVersion;
+  if (lockJson.packages?.[""]) {
+    // npm stores the version twice, and a mismatch makes `npm ci` refuse to
+    // install.
+    lockJson.packages[""].version = nextVersion;
+  }
+
+  if (options.dryRun) {
+    return {
+      ...base,
+      outcome: "dry-run",
+      reason: `Would release ${nextVersion}.`,
+    };
+  }
+
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .slice(0, 10);
+  const branch = `${RELEASE_BRANCH_PREFIX}${stamp}`;
+  const message = `chore(release): hourly v${nextVersion}`;
+
+  const commitSha = await createReleaseBranchWithCommit(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    branch,
+    baseBranch,
+    message,
+    [
+      { path: manifestFile, contents: `${JSON.stringify(manifestJson, null, 2)}\n` },
+      { path: lockFile, contents: `${JSON.stringify(lockJson, null, 2)}\n` },
+    ],
+  );
+
+  const prUrl = await createReleasePr(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    branch,
+    baseBranch,
+    message,
+    [
+      "Version-only release prepared by the hourly schedule.",
+      "",
+      `- Version: \`${nextVersion}\``,
+      `- Tag on merge: \`${tagName}\``,
+      "",
+      `Publishing happens after merge, from the manifest change on \`${baseBranch}\`.`,
+    ].join("\n"),
+  );
+
+  if (base.autoMergeRequested) {
+    await enableAutoMerge(
+      options.githubToken,
+      options.repoOwner,
+      options.repoName,
+      prUrl,
+    );
+  }
+
+  return {
+    ...base,
+    outcome: "opened",
+    reason: `Opened release pull request for ${nextVersion}.`,
+    prUrl,
+    branch,
+    commitSha,
+  };
+}
+
 /**
  * Tags and creates a GitHub Release without publishing a package.
  *
@@ -545,6 +710,9 @@ export async function releasePackage(
     case "prepare-hourly-release":
       result = await prepareHourlyRelease(options);
       break;
+    case "hourly-release":
+      result = await hourlyRelease(options);
+      break;
     case "github-only":
       result = await githubOnlyRelease(options);
       break;
@@ -556,7 +724,7 @@ export async function releasePackage(
       // destructive branch. Fail instead.
       throw new Error(
         `Unknown release action "${options.action}". Expected one of: ` +
-          "sync-pr-version, prepare-hourly-release, publish, github-only.",
+          "sync-pr-version, prepare-hourly-release, hourly-release, publish, github-only.",
       );
   }
 

--- a/src/publish/types.ts
+++ b/src/publish/types.ts
@@ -4,6 +4,7 @@ export type ReleasePackageAction =
   | "sync-pr-version"
   | "publish"
   | "prepare-hourly-release"
+  | "hourly-release"
   | "github-only";
 
 export interface ReleasePackageOptions {
@@ -54,6 +55,25 @@ export interface ReleasePackageOptions {
    * Pull request branch being synchronized.
    */
   prBranch?: string;
+
+  /**
+   * Compute the release and stop. Nothing is branched, committed, or merged.
+   */
+  dryRun?: boolean;
+
+  /**
+   * Ask GitHub to merge the release pull request once required checks pass.
+   */
+  autoMerge?: boolean;
+
+  /**
+   * Age at which an unmerged release pull request is treated as stalled.
+   *
+   * The in-flight guard exits successfully by design, so without this a single
+   * failing check halts releases indefinitely while every run still reports
+   * success.
+   */
+  stalePrHours?: number;
 }
 
 export interface PackageManifest {
@@ -117,6 +137,28 @@ export interface PrepareHourlyReleaseResult {
   lockfileContent?: string;
 }
 
+export interface HourlyReleaseResult {
+  action: "hourly-release";
+  packageName: string;
+  currentVersion: string;
+  nextVersion: string;
+  tagName: string;
+  /**
+   * skipped-in-flight, nothing-to-release, dry-run, or opened. The caller
+   * renders this rather than inferring intent from which fields are set.
+   */
+  outcome:
+    | "skipped-in-flight"
+    | "nothing-to-release"
+    | "dry-run"
+    | "opened";
+  reason: string;
+  prUrl?: string;
+  branch?: string;
+  commitSha?: string;
+  autoMergeRequested: boolean;
+}
+
 export interface GithubOnlyReleaseResult {
   action: "github-only";
   version: string;
@@ -130,4 +172,5 @@ export type ReleasePackageResult =
   | SyncPrVersionResult
   | PublishPackageResult
   | PrepareHourlyReleaseResult
+  | HourlyReleaseResult
   | GithubOnlyReleaseResult;

--- a/src/staydevops-ts.ts
+++ b/src/staydevops-ts.ts
@@ -765,10 +765,14 @@ export class StaydevopsTs {
     baseBranch?: string,
     packagePath?: string,
     prBranch?: string,
+    dryRun = false,
+    autoMerge = true,
+    stalePrHours = 6,
   ): Promise<string> {
     const supported = [
       "sync-pr-version",
       "prepare-hourly-release",
+      "hourly-release",
       "publish",
       "github-only",
     ] as const;
@@ -789,6 +793,9 @@ export class StaydevopsTs {
       baseBranch,
       packagePath,
       prBranch,
+      dryRun,
+      autoMerge,
+      stalePrHours,
     });
   }
 }


### PR DESCRIPTION
## Why

The first attempt drove the hourly cycle from workflow shell. It failed on its **first run**:

```
gh: command not found      (exit 127)
```

The shared runners carry no `gh`. And checking every pre-existing `shr` workflow:

| Workflow | `gh` | `jq` |
| --- | --- | --- |
| `checks-reusable.yml` | 0 | 0 |
| `release-reusable.yml` | 0 | 0 |
| `issue-reminders.yml` | 0 | 0 |
| `rss-feed-schedules.yml` | 0 | 0 |

They all use `curl`. My three `jq` calls were the same latent failure — unreached only because the run died on `gh` first.

**The real problem was layering.** The plan says keep logic in the module and the workflows thin. I had put the in-flight check, ref creation, commit, PR creation, and auto-merge on the host. Dagger exists so the runner needs Docker and nothing else — and the module already installs `github-cli` in containers and already commits through `createCommitOnBranch`.

Worth correcting something I said earlier: I called the raw `curl -sS -X POST` release call in `release-reusable.yml` a shortcoming to replace with `gh release create`. It wasn't sloppiness — it was the author working around exactly this constraint. Their `curl` was more correct than my `gh`.

## What

`hourly-release` runs the whole cycle in containers:

1. In-flight PR guard, with a staleness threshold that **fails** rather than exiting green
2. Next-version calculation and tag-existence check
3. Branch + **signed** commit via `createCommitOnBranch`
4. Pull request, then optional auto-merge

`dry_run` returns the computed release without mutating anything, so a dry run is genuinely dry.

## Signed commits are not incidental

`staycore` requires signatures and currently targets only the default branch — so an unsigned commit on `release/*` happens to pass **today**. Depending on that breaks the release flow with an opaque signature error the day anyone widens the ruleset. `createCommitOnBranch` produces GitHub-signed commits and doesn't care either way.

## Explicit outcome

`skipped-in-flight` | `nothing-to-release` | `dry-run` | `opened` — so a caller renders the result rather than inferring intent from which fields happen to be set.

## Verification

- `tsc` build passes.
- `dagger -m . functions` loads the module against `v1.0.0-beta.7`, action reachable.
- Companion staydevops workflows now show **`gh=0`, `jq=0`** — matching the pre-existing shr workflows exactly.

Closes #155