### PR TITLE
chore(release): bump manifest to 1.10.0 for the v1.10.0 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Manifest and lockfile → `1.10.0`. Three lines.

#156 added `hourly-release` but callers pin tags, so it is unreachable at `v1.9.0`. The staydevops hourly workflow cannot move to the container-based cycle — the one that needs no `gh` or `jq` on the runner — until a tag carries it.

After merge: tag `v1.10.0`, then move the staydevops pin and push the thin workflows.

Minor rather than patch — new public action, no breaking change to existing callers.

Verified: only version lines changed, `tsc` build passes at the new version, and `main` contains `hourly-release` before branching.

Closes #157