### PR TITLE
fix(release): two module bugs found from real repository data

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -457,26 +457,34 @@ export async function createReleaseBranchWithCommit(
   files: { path: string; contents: string }[],
 ): Promise<string> {
   const additions = files
-    .map(
-      (f) =>
-        `{ path: ${JSON.stringify(f.path)}, contents: $c${files.indexOf(f)} }`,
-    )
+    .map((f, i) => `{ path: ${JSON.stringify(f.path)}, contents: $c${i} }`)
     .join(", ");
 
-  const varDecls = files
-    .map((_, i) => `$c${i}: Base64String!`)
-    .join(", ");
+  const varDecls = files.map((_, i) => `$c${i}: Base64String!`).join(", ");
 
-  const fileWrites = files
+  const fileFlags = files.map((_, i) => `-F c${i}=@/tmp/c${i}.b64`).join(" ");
+
+  // Contents are mounted as files, never interpolated into the command.
+  //
+  // The first version embedded them via shellQuote. A live run died on it:
+  // staydevops' package-lock.json is 687 KB, and once escaped and placed
+  // alongside the GraphQL query in a single `sh -c` string it exceeds ARG_MAX
+  // (1 MB) and the exec fails with the whole lockfile in the error output. A
+  // dry run cannot catch this, because it returns before mutating anything.
+  let container = ghContainer(githubToken, repoOwner, repoName);
+
+  for (const [i, file] of files.entries()) {
+    container = container.withNewFile(`/tmp/c${i}.raw`, file.contents);
+  }
+
+  const encodeSteps = files
     .map(
-      (f, i) =>
-        `printf '%s' ${shellQuote(f.contents)} | base64 | tr -d '\\n' > /tmp/c${i}`,
+      (_, i) =>
+        `base64 -w 0 /tmp/c${i}.raw > /tmp/c${i}.b64 2>/dev/null || base64 /tmp/c${i}.raw | tr -d '\\n' > /tmp/c${i}.b64`,
     )
     .join("\n");
 
-  const fileFlags = files.map((_, i) => `-F c${i}=@/tmp/c${i}`).join(" ");
-
-  const output = await ghContainer(githubToken, repoOwner, repoName)
+  const output = await container
     .withExec([
       "sh",
       "-c",
@@ -484,7 +492,7 @@ export async function createReleaseBranchWithCommit(
         "set -eu",
         `head_oid="$(gh api "repos/${repoOwner}/${repoName}/git/ref/heads/${baseBranch}" --jq .object.sha)"`,
         `gh api "repos/${repoOwner}/${repoName}/git/refs" -f ref=${shellQuote(`refs/heads/${branch}`)} -f sha="$head_oid" >/dev/null`,
-        fileWrites,
+        encodeSteps,
         `query='mutation($repo: String!, $branch: String!, $oid: GitObjectID!, $message: String!, ${varDecls}) { createCommitOnBranch(input: { branch: { repositoryNameWithOwner: $repo, branchName: $branch }, message: { headline: $message }, expectedHeadOid: $oid, fileChanges: { additions: [ ${additions} ] } }) { commit { oid } } }'`,
         `gh api graphql -f query="$query" -F repo=${shellQuote(`${repoOwner}/${repoName}`)} -F branch=${shellQuote(branch)} -F oid="$head_oid" -F message=${shellQuote(message)} ${fileFlags} --jq '.data.createCommitOnBranch.commit.oid'`,
       ].join("\n"),

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -446,10 +446,13 @@ async function prepareHourlyRelease(
   manifestJson.version = nextVersion;
 
   const lockJson = JSON.parse(await options.source.file(lockFile).contents());
-  lockJson.version = nextVersion;
-  if (lockJson.packages?.[""]) {
-    // npm keeps the version in two places and a mismatch makes `npm ci` refuse
-    // to install, so both move together.
+
+  // Update the version only where npm already wrote one -- see hourlyRelease
+  // for why. gonow.travel's lockfile has it in neither place.
+  if (typeof lockJson.version === "string") {
+    lockJson.version = nextVersion;
+  }
+  if (typeof lockJson.packages?.[""]?.version === "string") {
     lockJson.packages[""].version = nextVersion;
   }
 
@@ -555,10 +558,16 @@ async function hourlyRelease(
   manifestJson.version = nextVersion;
 
   const lockJson = JSON.parse(await options.source.file(lockFile).contents());
-  lockJson.version = nextVersion;
-  if (lockJson.packages?.[""]) {
-    // npm stores the version twice, and a mismatch makes `npm ci` refuse to
-    // install.
+
+  // Update the version only where npm already wrote one. A private application
+  // whose manifest carries no version has a lockfile with none either
+  // (gonow.travel is shaped exactly this way), and injecting the key would
+  // produce a lockfile npm never generated. Where both copies exist they must
+  // move together, because a mismatch makes `npm ci` refuse to install.
+  if (typeof lockJson.version === "string") {
+    lockJson.version = nextVersion;
+  }
+  if (typeof lockJson.packages?.[""]?.version === "string") {
     lockJson.packages[""].version = nextVersion;
   }
 


### PR DESCRIPTION
Two bugs in the hourly release actions, both found from real repository data rather than from a failing test.

## 1. Lockfile version injected where npm wrote none

`hourly-release` and `prepare-hourly-release` set `lockJson.version` unconditionally.

| Repo | top-level `version` | `packages[""].version` |
| --- | --- | --- |
| `staystack` | `1.8.77` | `1.8.77` |
| `gonow.travel` | **absent** | **absent** |

gonow.travel is a private application — its manifest had no version either, which is why it needed a `0.0.6` baseline before it could use this flow at all. Writing the key unconditionally would produce a lockfile npm never generated.

Both writes are now guarded on the key already existing. Where both copies exist they still move together, since a mismatch makes `npm ci` refuse to install.

**Verified** by simulating against both real lockfiles:

```
staystack      before=string/string        after=9.9.9/9.9.9
gonow.travel   before=undefined/undefined  after=(absent)/(absent)
```

## 2. File contents interpolated into a shell command — E2BIG

A **live** hourly run on staydevops failed in the module. `createReleaseBranchWithCommit` passed the manifest and lockfile contents through `shellQuote` into a single `sh -c` string:

```
staydevops package-lock.json: 686,711 bytes
ARG_MAX:                    1,048,576 bytes
```

Escaped, and placed alongside the GraphQL query in the same command, that exceeds the limit. The exec failed with the entire lockfile in the error output.

**A dry run cannot catch this** — it returns before mutating, so the oversized command is never built. That is precisely why the dry run passed and the live run did not, and it is the argument for doing a live run with `auto_merge` off rather than trusting a dry one.

Contents now go in through `withNewFile` and are referenced by path, so command length is independent of file size. `base64 -w 0` with a portable fallback, since busybox base64 in alpine has no `-w`.

## Verification

- `tsc` build passes; module loads and the action is reachable.
- No file contents remain in any shell string.
- Both lockfile write sites guarded.

Closes #159