### PR TITLE
fix(ci): read the Dagger version from dagger.json, not a literal

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,9 +43,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Read the version from this repository's own dagger.json rather than
+          # repeating it here. daggerverse is the authority -- engineVersion is
+          # what the module loader enforces -- so a literal in this file is a
+          # copy that can disagree with the module it installs a CLI for.
+          #
+          # staydevops mirrors this value in .github/dagger-version and its
+          # dagger-version-drift workflow fails when the two diverge. That guard
+          # is pointless if the authority itself carries a second copy.
+          version="$(jq -r .engineVersion dagger.json)"
+          if [ -z "${version}" ] || [ "${version}" = "null" ]; then
+            echo "::error file=dagger.json::engineVersion is missing or empty."
+            exit 1
+          fi
+          echo "Installing Dagger ${version} from dagger.json"
+
           INSTALL_DIR="$HOME/.local/bin"
           mkdir -p "$INSTALL_DIR"
-          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION="v1.0.0-beta.7" BIN_DIR="$INSTALL_DIR" sh
+          curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION="${version}" BIN_DIR="$INSTALL_DIR" sh
           echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       - name: Resolve check pattern


### PR DESCRIPTION
Removes the last private copy of the Dagger version in the organisation.

## Why

`daggerverse` **is** the authority — `dagger.json`'s `engineVersion` is what the module loader enforces. A literal in `checks.yml` is a second copy that can disagree with the module it installs a CLI for:

```diff
- curl ... | DAGGER_VERSION="v1.0.0-beta.7" BIN_DIR="$INSTALL_DIR" sh
+ version="$(jq -r .engineVersion dagger.json)"
+ curl ... | DAGGER_VERSION="${version}" BIN_DIR="$INSTALL_DIR" sh
```

`staydevops` mirrors this value in `.github/dagger-version`, and its `dagger-version-drift` workflow fails when the two diverge. **That guard is pointless if the authority itself carries a duplicate** — and this literal is precisely what motivated the guard's second job.

## Also

Fails clearly if `engineVersion` is missing or empty, rather than installing whatever `DAGGER_VERSION=""` resolves to.

`jq` is present on `ubuntu-latest`, which this workflow uses — unlike the `shr` runners, where three dispatches proved it is not. Worth stating because the same assumption in the wrong place cost real time today.

## Verification

- YAML parses; no version literal remains.
- Simulated read against the checked-in file returns `v1.0.0-beta.7`.

Closes #161

<!-- rechecked: org blocker issues cleared -->
