### PR TITLE
chore(release): bump manifest to 1.10.1 for the v1.10.1 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Manifest and lockfile → `1.10.1`. Three lines.

`v1.10.0` **cannot complete a live release**: `createReleaseBranchWithCommit` interpolated file contents into a single `sh -c` string, and staydevops' 687 KB lockfile exceeds `ARG_MAX` (1 MB) once escaped alongside the GraphQL query.

A dry run returns before mutating, so it never builds the oversized command — which is exactly why the dry run passed and the live run failed. #160 fixed it with `withNewFile`; this makes it reachable.

Patch rather than minor: two bug fixes, no API change.

Verified: only version lines changed, `tsc` passes, and `main` carries both the `withNewFile` fix and the lockfile guards.

Closes #163