### PR TITLE
fix(release): create the release issue through gh api, not gh issue create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -593,20 +593,28 @@ export async function createReleaseIssue(
   ].join("\n");
 
   const output = await ghContainer(githubToken, repoOwner, repoName)
-    // Body goes in as a file, never as a command argument: it contains
-    // backticks and markdown, and a large or quoted payload on the command line
-    // is how the release branch commit hit ARG_MAX.
-    .withNewFile("/tmp/issue-body.md", body)
+    // Payload goes in as a file, never as command arguments: it contains
+    // markdown and backticks, and a quoted payload on the command line is how
+    // the release branch commit hit ARG_MAX.
+    .withNewFile(
+      "/tmp/issue.json",
+      JSON.stringify({ title: `Release ${version}`, body, type: issueType }),
+    )
     .withExec([
       "sh",
       "-c",
       [
         "set -eu",
-        `url="$(gh issue create --title ${shellQuote(`Release ${version}`)} --type ${shellQuote(issueType)} --body-file /tmp/issue-body.md)"`,
-        `number="\${url##*/}"`,
-        // Priority is a separate org-level field, not an issue attribute, so it
-        // needs its own call. Without it, issue-priority fails.
-        `gh api "repos/${repoOwner}/${repoName}/issues/\${number}/issue-field-values" --method POST -H "X-GitHub-Api-Version: 2026-03-10" -f 'issue_field_values[][field_id]=${priorityFieldId}' -f 'issue_field_values[][value]=${priority}' >/dev/null 2>&1 || true`,
+        // gh api rather than `gh issue create`. The alpine github-cli package
+        // ships a gh that predates issue types, so `gh issue create --type`
+        // fails with "unknown flag: --type". gh api proxies REST directly and
+        // does not depend on the CLI's flag surface.
+        `number="$(gh api "repos/${repoOwner}/${repoName}/issues" --method POST --input /tmp/issue.json --jq .number)"`,
+        // Priority is an org-level custom field, not an issue attribute, so it
+        // needs its own call. Tolerated on failure: a missing priority fails a
+        // policy check with a clear message, which is better than losing the
+        // issue and the release with it.
+        `gh api "repos/${repoOwner}/${repoName}/issues/\${number}/issue-field-values" --method POST -H "X-GitHub-Api-Version: 2026-03-10" -f 'issue_field_values[][field_id]=${priorityFieldId}' -f 'issue_field_values[][value]=${priority}' >/dev/null 2>&1 || echo "warning: could not set Priority on issue \${number}" >&2`,
         `printf '%s' "\${number}"`,
       ].join("\n"),
     ])

--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -600,6 +600,12 @@ export async function createReleaseIssue(
       "/tmp/issue.json",
       JSON.stringify({ title: `Release ${version}`, body, type: issueType }),
     )
+    .withNewFile(
+      "/tmp/fields.json",
+      JSON.stringify({
+        issue_field_values: [{ field_id: priorityFieldId, value: priority }],
+      }),
+    )
     .withExec([
       "sh",
       "-c",
@@ -614,7 +620,13 @@ export async function createReleaseIssue(
         // needs its own call. Tolerated on failure: a missing priority fails a
         // policy check with a clear message, which is better than losing the
         // issue and the release with it.
-        `gh api "repos/${repoOwner}/${repoName}/issues/\${number}/issue-field-values" --method POST -H "X-GitHub-Api-Version: 2026-03-10" -f 'issue_field_values[][field_id]=${priorityFieldId}' -f 'issue_field_values[][value]=${priority}' >/dev/null 2>&1 || echo "warning: could not set Priority on issue \${number}" >&2`,
+        // Priority needs a JSON body via --input. The bracketed -f form
+        // encoding that gh normally accepts is rejected by this endpoint --
+        // verified against a live repository, where -f silently left the field
+        // unset while --input set it. An unset Priority fails the
+        // issue-priority policy check, so the release pull request could not
+        // merge.
+        `gh api "repos/${repoOwner}/${repoName}/issues/\${number}/issue-field-values" --method POST -H "X-GitHub-Api-Version: 2026-03-10" --input /tmp/fields.json >/dev/null 2>&1 || echo "warning: could not set Priority on issue \${number}" >&2`,
         `printf '%s' "\${number}"`,
       ].join("\n"),
     ])


### PR DESCRIPTION
Live releases on **staylook** and **staystack** both failed at the same step, in 0.1s:

```
unknown flag: --type
Usage:  gh issue create [flags]
```

The alpine `github-cli` package ships a `gh` that predates issue types. My local `gh` supports `--type`; the container's does not.

## Third instance of one mistake

| Assumption | Reality |
| --- | --- |
| `gh`, `jq`, `node` on the runner | absent — three failed dispatches |
| file contents fit in a command | 687 KB lockfile vs 1 MB `ARG_MAX` |
| container `gh` matches local `gh` | **older; no `--type`** |

What made this one slip through: `gh release create --verify-tag --generate-notes` **does** work in that container, so newer flags are partly present. Version-checking one command told me nothing about another.

## Fix

`gh api` proxies REST directly and does not depend on the CLI's flag surface. The payload goes in as a JSON file — same discipline as the ARG_MAX fix.

The priority call now warns to stderr rather than swallowing failure silently, so a missing priority surfaces as a readable policy-check failure instead of a mystery.

## Verification

- `tsc` passes; no `gh issue create` invocation remains, only comments explaining why.
- Rendered the exact shell the container receives and ran `bash -n` on it — `${number}` survives as a shell variable rather than being interpolated by TypeScript.
- Manifest bumped to `1.10.3`.

Closes #167
