### PR TITLE
fix(release): report auto-merge failure instead of aborting the release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -540,14 +540,32 @@ export async function enableAutoMerge(
   repoOwner: string,
   repoName: string,
   prUrl: string,
-): Promise<void> {
-  await ghContainer(githubToken, repoOwner, repoName)
+): Promise<boolean> {
+  // Reported rather than thrown. By the time this runs the release pull request
+  // exists, so failing the whole action would report a release that did not
+  // happen and leave an orphan pull request behind.
+  //
+  // It genuinely fails: staystack has allow_auto_merge disabled at the
+  // repository level, so `gh pr merge --auto` cannot succeed there no matter
+  // what the token can do. The release is still correct -- it just needs a
+  // human to merge it.
+  const output = await ghContainer(githubToken, repoOwner, repoName)
     .withExec([
       "sh",
       "-c",
-      ["set -eu", `gh pr merge ${shellQuote(prUrl)} --auto --squash`].join("\n"),
+      [
+        "set -eu",
+        `if gh pr merge ${shellQuote(prUrl)} --auto --squash 2>/tmp/err; then`,
+        `  printf 'enabled'`,
+        "else",
+        `  echo "warning: could not enable auto-merge: $(cat /tmp/err)" >&2`,
+        `  printf 'unavailable'`,
+        "fi",
+      ].join("\n"),
     ])
-    .sync();
+    .stdout();
+
+  return output.trim() === "enabled";
 }
 
 /**

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -635,8 +635,9 @@ async function hourlyRelease(
     ].join("\n"),
   );
 
+  let autoMergeEnabled = false;
   if (base.autoMergeRequested) {
-    await enableAutoMerge(
+    autoMergeEnabled = await enableAutoMerge(
       options.githubToken,
       options.repoOwner,
       options.repoName,
@@ -647,10 +648,13 @@ async function hourlyRelease(
   return {
     ...base,
     outcome: "opened",
-    reason: `Opened release pull request for ${nextVersion}.`,
+    reason: base.autoMergeRequested && !autoMergeEnabled
+      ? `Opened release pull request for ${nextVersion}. Auto-merge is unavailable in this repository, so it needs a manual merge.`
+      : `Opened release pull request for ${nextVersion}.`,
     prUrl,
     branch,
     commitSha,
+    autoMergeEnabled,
   };
 }
 

--- a/src/publish/types.ts
+++ b/src/publish/types.ts
@@ -185,6 +185,12 @@ export interface HourlyReleaseResult {
   branch?: string;
   commitSha?: string;
   autoMergeRequested: boolean;
+  /**
+   * Whether auto-merge was actually enabled. False when the repository has
+   * allow_auto_merge disabled, in which case the release is still correct and
+   * simply needs a manual merge.
+   */
+  autoMergeEnabled?: boolean;
 }
 
 export interface GithubOnlyReleaseResult {


### PR DESCRIPTION
## Why

staystack's live release created its pull request correctly — signed commit, auto-created issue #500, version `1.8.78` — and then the run **failed**:

```
✘ withExec sh -c 'gh pr merge .../pull/501 --auto --squash'
```

| Repo | `allow_auto_merge` |
| --- | --- |
| staydevops | true |
| staylook | true |
| **staystack** | **false** |
| gonow.travel | true |

`gh pr merge --auto` cannot succeed where the repository disables auto-merge, regardless of token permissions.

## Throwing there is wrong twice over

1. It reports a **failed release for one that succeeded** — the PR exists and is correct.
2. It leaves an orphan pull request, which the next run's in-flight guard then skips on, so the release train stalls on a release that already worked.

Auto-merge is now reported rather than thrown: `autoMergeEnabled` in the result, and the `reason` says a manual merge is needed.

## Verification

- `tsc` passes.
- Manifest bumped to `1.10.4`.

Closes #171
