### PR TITLE
fix(checks): a version-only manifest change is not infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@staytunedllp/daggerverse",
-      "version": "1.10.4",
+      "version": "1.11.0",
       "dependencies": {
         "typescript": "^6.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/checks/affected-node-tests.runtime.ts
+++ b/src/checks/affected-node-tests.runtime.ts
@@ -343,6 +343,59 @@ function getReverseGraph(graph: PackageGraph): PackageGraph {
   return reverse;
 }
 
+/**
+ * Reports whether a manifest change touched anything other than the version.
+ *
+ * package.json and package-lock.json are treated as infrastructure, because a
+ * dependency or script change really can affect every package. A version bump
+ * cannot: it changes no dependency and no code.
+ *
+ * That distinction matters because the hourly release opens a version-only pull
+ * request, and treating it as infrastructure runs the entire test suite for a
+ * three-line diff. On a shared 7.7 GiB runner that is enough to get the runner
+ * OOM-killed mid-run, which fails the check and blocks the release.
+ *
+ * Conservative by construction: anything that cannot be proven version-only --
+ * an unreadable diff, an added or deleted file, any other changed key -- is
+ * still treated as infrastructure. Under-running checks is worse than
+ * over-running them.
+ */
+function manifestChangeIsVersionOnly(file: string): boolean {
+  const safeBaseRef = assertSafeBaseRef(baseRef);
+
+  for (const range of [`${safeBaseRef}...HEAD`, "HEAD~1"]) {
+    try {
+      const out = execSync(
+        `git diff --unified=0 ${range} -- ${JSON.stringify(file)}`,
+        { stdio: ["ignore", "pipe", "ignore"], encoding: "utf-8" },
+      );
+
+      const changedLines = out
+        .split("\n")
+        .filter(
+          (line) =>
+            (line.startsWith("+") || line.startsWith("-")) &&
+            !line.startsWith("+++") &&
+            !line.startsWith("---"),
+        );
+
+      if (changedLines.length === 0) {
+        continue;
+      }
+
+      // Every changed line must be a version assignment. npm writes the version
+      // in two places in a lockfile, so several lines is normal.
+      return changedLines.every((line) =>
+        /^[+-]\s*"version"\s*:\s*"[^"]*",?\s*$/.test(line),
+      );
+    } catch {
+      // Try the next range.
+    }
+  }
+
+  return false;
+}
+
 function affectedPackages(
   changed: WorkspaceDir[],
   allFiles: string[],
@@ -355,12 +408,12 @@ function affectedPackages(
         !file.startsWith(".github/") &&
         !file.startsWith("dagger/") &&
         (file.includes("tools/scripts/") ||
-          file.endsWith("package.json") ||
           file.endsWith("tsconfig.json") ||
           file.endsWith("yarn.lock") ||
-          file.endsWith("package-lock.json") ||
           file.endsWith("playwright.config.ts") ||
-          file.endsWith("eslint.config.ts")),
+          file.endsWith("eslint.config.ts") ||
+          ((file.endsWith("package.json") || file.endsWith("package-lock.json")) &&
+            !manifestChangeIsVersionOnly(file))),
     );
 
     return infrastructureChanged ? packageNames : [];


### PR DESCRIPTION
## Summary

A version-only release pull request is treated as an infrastructure change, so it runs the entire test suite.

## Acceptance Criteria

- [x] A manifest diff touching only `version` does not mark every package affected.
- [x] Any other manifest change still does.
- [x] Anything unprovable stays infrastructure.

## Context

`package.json` and `package-lock.json` are in the `infrastructureChanged` list, which is correct in general — a dependency or script change really can affect every package. A version bump cannot: it changes no dependency and no code.

The consequence showed up on staylook's release pull request. A three-line version diff ran the full suite, the suite exhausted memory on a shared 7.7 GiB runner, and the runner was killed mid-run:

```
##[error]The runner has received a shutdown signal.
```

The check then failed and the release could not merge. Five of eight runners in the fleet were offline at that point, two of them killed the same day.

Conservative by construction: an unreadable diff, an added or deleted file, or any other changed key is still treated as infrastructure. Under-running checks is worse than over-running them.

The version-line pattern was tested against eight real diff shapes including a `versionRange` near-miss that a looser pattern would have matched.

Closes #173
