### PR TITLE
feat(checks): add the -changed functions the local profile needs

### DIFF
--- a/src/checks/affected-node-tests.runtime.ts
+++ b/src/checks/affected-node-tests.runtime.ts
@@ -450,7 +450,20 @@ function run(): void {
 
     const files = getDiff();
     const changed = changedPackages(files, workspaceDirs);
-    const affected = affectedPackages(changed, files, packageNames, reverseGraph);
+
+    // The local profile stops at the packages whose own files changed; pr and
+    // main additionally pull in every dependent through the reverse graph. A
+    // developer waiting on their own terminal wants the narrow answer, and the
+    // DAG is what the pull request is for.
+    //
+    // The empty-changed case still goes through affectedPackages either way:
+    // it carries the infrastructure-change fallback, and skipping that would
+    // make a tsconfig or lockfile edit silently select no tests at all.
+    const expandToDependents = process.env.INCLUDE_DEPENDENTS !== "0";
+    const affected =
+      expandToDependents || changed.length === 0
+        ? affectedPackages(changed, files, packageNames, reverseGraph)
+        : packageNames.filter((packageName) => changed.includes(packageName));
 
     // If everything is affected or base config changed, run everything
     const allTests = workspaceDirs.flatMap((dir) => findTestFiles(dir));

--- a/src/checks/node-checks.ts
+++ b/src/checks/node-checks.ts
@@ -172,7 +172,14 @@ export async function runNodeChecks(
     // available to consumer `*:incremental` scripts.
     workspace = workspace
       .withEnvVariable("CHANGED_FILES", options.changedFiles ?? "")
-      .withEnvVariable("BASE_REF", options.base ?? "");
+      .withEnvVariable("BASE_REF", options.base ?? "")
+      // Read by the affected-selection runtime. Only "0" narrows the selection,
+      // so an unset or malformed value keeps the pr/main behaviour rather than
+      // quietly shrinking what a pull request tests.
+      .withEnvVariable(
+        "INCLUDE_DEPENDENTS",
+        options.includeDependents === false ? "0" : "1",
+      );
   }
 
   for (const packagePath of packagePaths) {

--- a/src/checks/types.ts
+++ b/src/checks/types.ts
@@ -14,4 +14,14 @@ export type NodeChecksOptions = {
   base?: string;
   changedFiles?: string;
   nodeMaxOldSpaceMb?: number;
+
+  /**
+   * Whether an affected run expands the changed set through the reverse
+   * dependency graph. Defaults to true, which is pr and main behaviour.
+   *
+   * Set false for the local profile, which reports only the packages whose own
+   * files changed. Ignored when runAffected is false -- a full run has no
+   * changed set to expand.
+   */
+  includeDependents?: boolean;
 };

--- a/src/staydevops-ts.ts
+++ b/src/staydevops-ts.ts
@@ -332,6 +332,57 @@ export class Checks {
       changedFiles: this.changedFiles,
     });
   }
+
+  // The local profile: only the packages whose own files changed, for a
+  // developer waiting on their own terminal. checks-reusable.yml maps
+  // profile local to the -changed suffix and always runs all four names, so
+  // every one of these has to exist even where it does no less work than its
+  // -incremental sibling.
+  //
+  // format and lint genuinely do no less work. Their affected path runs the
+  // repository's own format:incremental / lint:incremental, which filter to
+  // changed files and never consult the dependency graph -- there is nothing
+  // narrower to ask for. They delegate rather than pretending to differ, so
+  // that a future divergence has one obvious place to happen.
+
+  @check()
+  @func({ cache: "never" })
+  async formatChanged(): Promise<void> {
+    await this.formatIncremental();
+  }
+
+  @check()
+  @func({ cache: "never" })
+  async lintChanged(): Promise<void> {
+    await this.lintIncremental();
+  }
+
+  @check()
+  @func({ cache: "never" })
+  async buildChanged(): Promise<void> {
+    await this.buildIncremental();
+  }
+
+  /**
+   * Unlike the other three, this one is genuinely narrower: the affected-test
+   * runtime is the only place the reverse dependency graph is walked, so
+   * suppressing that expansion is what makes the local profile local.
+   */
+  @check()
+  @func({ cache: "never" })
+  async testChanged(): Promise<void> {
+    await runNodeChecks(this.resolveSource(), this.resolveNodeAuthToken(), {
+      packagePaths: this.packagePaths,
+      registryScope: this.registryScope,
+      nodeMaxOldSpaceMb: this.heap,
+      test: true,
+      runAffected: true,
+      testScript: "verify:incremental",
+      base: this.checkBase,
+      changedFiles: this.changedFiles,
+      includeDependents: false,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #176

### The gap

`checks-reusable.yml` has always mapped `profile: local` to a `-changed` suffix:

```
local)            suffix="changed" ;;
pr|main)          suffix="incremental" ;;
nightly|release)  suffix="full" ;;
```

and always loops `for check_name in format lint test build`. But no `-changed`
function existed, so running the local profile failed on the first check with an
unknown-check error. CI only ever uses `pr`, `main`, `nightly`, and `release`, so
nothing was broken — the local half of the check contract simply never worked.

### Only one of the four is genuinely narrower

The reverse dependency graph is walked in exactly one place, the affected-test
runtime. So `testChanged` suppresses that expansion and that is what makes the
local profile local.

`format` and `lint` delegate to their `-incremental` siblings, because the
affected path for those runs the repository's own `format:incremental` /
`lint:incremental`, which filter to changed files and never consult the graph.
There is nothing narrower to ask them for. They delegate explicitly, with the
reasoning in a comment, so that the apparent redundancy does not get "fixed"
later and so a future divergence has one obvious home.

`buildChanged` likewise delegates: build's affected path resolves through a
per-repo `build:incremental` fallback chain, so narrowing it needs those
semantics pinned down per repo first.

### Two fail-safe choices

`INCLUDE_DEPENDENTS` narrows only on the literal `"0"`. Unset, empty, or
malformed keeps pr/main behaviour — the failure mode of getting this backwards is
a pull request quietly testing less than it claims to.

The empty-changed case still routes through `affectedPackages` even when
narrowed, because that path carries the infrastructure-change fallback. Skipping
it would make a `tsconfig` or lockfile edit select no tests at all.

### Verification

- `tsc --noEmit` clean
- 13/13 cases on the env round-trip, including `""`, `"false"`, `"00"`, `" 0 "` —
  all correctly keep the expanding behaviour; only `"0"` narrows

Not yet verified end to end: this needs a tag, pin bumps in the consumer repos,
and a `check:local` wrapper before `profile: local` actually runs anywhere. I
have not run a real `local` profile against a repo, so treat the wiring as
tested and the end-to-end path as not.
