### PR TITLE
chore(release): bump manifest to 1.12.0 for the v1.12.0 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@staytunedllp/daggerverse",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Shared TypeScript helpers for Staytuned Dagger modules",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #177

The manifest version and the git tag are kept in step here, so the tag needs the
manifest moved first. `v1.12.0` carries the `-changed` check functions from #175.

### Note for follow-up

This repository has no release workflow at all — only `checks.yml` and
`copilot-setup-steps.yml`. Every tag so far, including this one, has been cut by
hand. That does not satisfy the one-cycle-per-repo rule the other four
repositories now follow, and it should get the `github-only` release mode since
daggerverse publishes by tag rather than to a registry.
