### PR TITLE
feat(release): give daggerverse the release cycle it never had

### DIFF
--- a/.github/workflows/release-hourly.yml
+++ b/.github/workflows/release-hourly.yml
@@ -1,0 +1,58 @@
+name: Release Hourly
+
+# One release cycle for this repository. Nothing else may cut a release.
+#
+# Until now this repository had no release workflow at all -- every tag was cut
+# by hand, which is how the manifest and the tags drifted apart more than once.
+# The other four repositories release through this same reusable flow; this
+# makes daggerverse the fifth rather than the exception.
+#
+# This repository publishes by tag, not to a registry: consumers load it as
+# `github.com/StaytunedLLP/daggerverse@vX.Y.Z`. So the publish half runs in
+# github-only mode and no registry credential is involved.
+
+on:
+  # Schedule intentionally left disabled until the runner pool can absorb it.
+  # Four staggered hourly jobs against three online runners queue indefinitely,
+  # and a release that waits an hour for a runner is not an hourly release.
+  #
+  # To enable: uncomment. :47 is this repository's slot in the stagger --
+  # staylook :07, staystack :17, staydevops :27, gonow.travel :37,
+  # daggerverse :47.
+  #
+  # schedule:
+  #   - cron: "47 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Compute the next release and stop.
+        required: false
+        default: false
+        type: boolean
+      auto_merge:
+        description: Ask GitHub to merge the release PR once required checks pass.
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: release-hourly-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    uses: staytunedllp/staydevops/.github/workflows/release-hourly-reusable.yml@main
+    secrets: inherit
+    with:
+      package_path: .
+      release_branch: main
+      # github.event_name rather than a null check on the input: GitHub
+      # expressions coerce null to false, so `inputs.auto_merge == null` is true
+      # when the input is explicitly false, which made auto-merge impossible to
+      # turn off. A scheduled run has no inputs at all, which is what the event
+      # check actually distinguishes.
+      dry_run: ${{ inputs.dry_run || false }}
+      auto_merge: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_merge }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,38 @@
+name: Release Publish
+
+# The second half of the one release cycle: the hourly job opens a release pull
+# request that moves the manifest, and merging it lands here.
+#
+# Gated on the manifest paths rather than every push to main, so ordinary commits
+# do not attempt a release. The version in package.json is the trigger and the
+# subject at once.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+concurrency:
+  group: release-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  # packages: write is required here even though github-only mode never touches a
+  # registry. A reusable workflow cannot be granted more than its caller has, and
+  # release-publish-reusable.yml declares packages: write for the registry modes.
+  # Granting less does not merely drop the scope -- the run fails at startup
+  # before any step executes, which is how this was found the first time.
+  packages: write
+
+jobs:
+  publish:
+    uses: staytunedllp/staydevops/.github/workflows/release-publish-reusable.yml@main
+    secrets: inherit
+    with:
+      mode: github-only
+      package_path: .
+      release_branch: main


### PR DESCRIPTION
Closes #179

This repository had no release workflow at all — only `checks.yml` and
`copilot-setup-steps.yml`. Every tag has been cut by hand, which is how the
manifest and the tags drifted apart more than once, and it is the one place the
one-cycle-per-repo rule was still unmet while the other four repos were converted.

The reusable workflows already supported this case: `release-publish-reusable.yml`
takes a `mode` input accepting `publish` or `github-only`. daggerverse is consumed
as a git ref, so `github-only` creates the tag and the Release and never contacts
npm. Only the callers were missing.

### On `packages: write`

The publish caller grants it even though `github-only` never touches a registry.
A reusable workflow cannot be granted more than its caller holds, and
`release-publish-reusable.yml` declares `packages: write` for its registry modes.
Granting less does not quietly drop the scope — the run fails at startup before
any step executes. I wrote this file without it first and checked rather than
shipped the tidier-looking version.

The hourly reusable declares no `permissions` block (it mints an app token), which
is why `contents: read` is right there — matching the three working callers.

### Not proven

The reusable is exercised daily by the other repositories, but nobody has run
`github-only` mode end to end. **The first daggerverse release through this flow
should be a `dry_run` dispatch**, which is why the acceptance criterion for that
is left unchecked on #179.

The schedule is commented out. Four staggered hourly jobs against three online
runners queue indefinitely; `:47` is this repository's slot when capacity allows.

### Verification

- both files parse; jobs, triggers, and permissions confirmed by parser rather than by eye
