### PR TITLE
feat(release): enable the hourly release schedule at :47

### DIFF
--- a/.github/workflows/release-hourly.yml
+++ b/.github/workflows/release-hourly.yml
@@ -21,8 +21,8 @@ on:
   # the runner pool can absorb it. :47 is this repository's slot in the stagger
   # -- staylook :07, staystack :17, staydevops :27, gonow.travel :37.
   #
-  # schedule:
-  #   - cron: "47 * * * *"
+  schedule:
+    - cron: "47 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -94,6 +94,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # A scheduled run carries no inputs at all, so a bare `inputs.dry_run`
+          # renders empty and the flag arrives as `--dry-run=` with no value.
+          # `|| false` supplies the scheduled default; an explicit false from a
+          # dispatch still evaluates to false, so this does not override the
+          # operator.
+          #
+          # auto-merge uses github.event_name rather than a null check, because
+          # GitHub coerces null to false: `inputs.auto_merge == null` is also
+          # true when the input is explicitly false, which is what previously
+          # made auto-merge impossible to turn off.
+          #
+          # Both are assigned before the command rather than inline: these lines
+          # are shell, and a comment between backslash-continued arguments would
+          # comment out the remainder of the command.
+          dry_run="${{ inputs.dry_run || false }}"
+          auto_merge="${{ github.event_name != 'workflow_dispatch' || inputs.auto_merge }}"
+
           dagger call release-package \
             --action=hourly-release \
             --source=. \
@@ -102,8 +120,8 @@ jobs:
             --repo-name="${{ github.event.repository.name }}" \
             --package-path=. \
             --base-branch=main \
-            --dry-run=${{ inputs.dry_run }} \
-            --auto-merge=${{ inputs.auto_merge }} \
+            --dry-run="${dry_run}" \
+            --auto-merge="${auto_merge}" \
             | tee /tmp/release.json
 
       - name: Summary


### PR DESCRIPTION
Closes #183

Enables the hourly release schedule at `:47`. Until now every release came from
a manual dispatch or a hand-merged release PR, so "hourly release" described the
wiring rather than the behaviour.

### Verified before enabling

A dry-run dispatch on daggerverse returned:

```json
{ "action": "hourly-release", "currentVersion": "1.12.0",
  "nextVersion": "1.12.1", "tagName": "v1.12.1",
  "outcome": "dry-run", "reason": "Would release 1.12.1." }
```

Correct version arithmetic and tag, and it created no branch and no pull
request.

### Why now, and not earlier

The binding constraint was never the workflow. The Dagger engine had run since
**2026-04-15** with no memory limit, holding roughly a third of each host before
any job started — that is what produced the OOM kills that cancelled three runs
today. Capping it took host available memory from **1.1 GiB to 6.8 GiB**, and
`shr02-r03` was retired so that host runs the two runners its four cores can
feed.

### Stagger

`:07` staylook, `:17` staystack, `:27` staydevops, `:37` gonow.travel,
`:47` daggerverse. Staggered rather than shared because five repositories firing
the same minute contend for a pool that serialises one atomic check per Dagger
session.

### Not yet verified

**No cron has actually fired.** Enabling a schedule is not the same as watching
one work, so that criterion stays unchecked on #183 until a scheduled run is
observed end to end.
