### PR TITLE
feat(checks): resolve the changed set from git inside the engine

### DIFF
--- a/src/checks/git-changed.ts
+++ b/src/checks/git-changed.ts
@@ -1,0 +1,146 @@
+import { dag, Directory, Secret } from "@dagger.io/dagger";
+
+/**
+ * Resolve the changed file set from git, inside the engine.
+ *
+ * The alternative this replaces is passing a comma-joined list in from the
+ * caller. That path has two costs, both paid in production:
+ *
+ * The list has to travel through a Dagger local default, and `env://` there is
+ * a *secret provider* URI -- it resolves for Secret-typed arguments and is
+ * handed through verbatim for plain strings. The changed set is a string, so it
+ * arrived as the literal text "env://CHANGED_FILES". Every consumer then failed
+ * silently, in both directions: the scoped scripts filtered the phantom path out
+ * and reported "no changes -- skip", becoming checks that could not fail, while
+ * staytest resolved it against the repo root and read it as a root-level change,
+ * escalating to every package plus a full build.
+ *
+ * And it requires `.git` in the container so the scripts can run `git diff`.
+ * `.git` measures 5-12x the tracked source in these repositories and its digest
+ * changes on every commit, so the workspace layer is re-materialised for each of
+ * the four checks.
+ *
+ * Resolving here removes both. The engine already has the repository, the
+ * result is a typed value rather than a string that can silently be the wrong
+ * thing, and it is cached on the commit digests.
+ */
+
+export interface GitChangedOptions {
+  /** Repository URL, https form. */
+  url: string;
+  /** Base ref to compare against, typically origin/main or a merge base sha. */
+  base: string;
+  /** Head ref. Defaults to the repository HEAD. */
+  head?: string;
+  /**
+   * Credential for private repositories. Populates the password during basic
+   * HTTP authorization, which is what a GitHub installation token needs.
+   */
+  token?: Secret;
+}
+
+/** A changed set, split by how each path changed. */
+export interface ChangedSet {
+  added: string[];
+  modified: string[];
+  removed: string[];
+  /**
+   * added + modified, the set that can actually be read from disk.
+   *
+   * Removed paths are deliberately excluded here and reported separately:
+   * prettier and eslint treat a missing path as an error rather than as nothing
+   * to do, so handing them a deleted file fails the run for the wrong reason.
+   * They are still worth knowing about -- a delete-only change currently gets
+   * no scoped checking at all, because the shell resolvers drop deletions with
+   * an existsSync filter and are then left with an empty set.
+   */
+  present: string[];
+}
+
+// Content only. `tree()` includes `.git` by default -- verified, it is in the
+// entries -- and shipping it is the thing this is meant to avoid. depth 1
+// because nothing here reads history: the base and head trees are compared as
+// content, not as commits.
+const TREE_OPTS = { discardGitDir: true, depth: 1 } as const;
+
+function repo(options: GitChangedOptions) {
+  return options.token
+    ? dag.git(options.url, { httpAuthToken: options.token })
+    : dag.git(options.url);
+}
+
+/** The tree at a ref, without .git. */
+export function treeAt(options: GitChangedOptions, ref: string): Directory {
+  return repo(options).ref(ref).tree(TREE_OPTS);
+}
+
+/**
+ * Paths that differ between base and head.
+ *
+ * Note this compares *trees*, not commits, so it reports the net difference.
+ * A file added and then reverted within the range does not appear, which is the
+ * correct scope for a check: the question is what the merge would change, not
+ * what happened along the way.
+ */
+export async function changedBetween(
+  options: GitChangedOptions,
+): Promise<ChangedSet> {
+  const source = repo(options);
+  const headTree = options.head
+    ? source.ref(options.head).tree(TREE_OPTS)
+    : source.head().tree(TREE_OPTS);
+  const baseTree = source.ref(options.base).tree(TREE_OPTS);
+
+  const changeset = headTree.changes(baseTree);
+
+  const [added, modified, removed] = await Promise.all([
+    changeset.addedPaths(),
+    changeset.modifiedPaths(),
+    changeset.removedPaths(),
+  ]);
+
+  return {
+    added,
+    modified,
+    removed,
+    present: [...new Set([...added, ...modified])].sort(),
+  };
+}
+
+/**
+ * Uncommitted changes: the local profile, natively.
+ *
+ * Replaces a merge-base diff unioned with `git ls-files --others`, which had to
+ * be hand-written once per repository and had already started to diverge
+ * between them.
+ */
+export async function uncommittedChanges(
+  options: GitChangedOptions,
+): Promise<ChangedSet> {
+  const changeset = repo(options).uncommitted();
+
+  const [added, modified, removed] = await Promise.all([
+    changeset.addedPaths(),
+    changeset.modifiedPaths(),
+    changeset.removedPaths(),
+  ]);
+
+  return {
+    added,
+    modified,
+    removed,
+    present: [...new Set([...added, ...modified])].sort(),
+  };
+}
+
+/**
+ * Comma-joined form, for consumers whose scripts still read CHANGED_FILES.
+ *
+ * The env variable is not going away in this change: the repository scripts
+ * read it, and replacing both halves at once would leave nothing to compare a
+ * regression against. This is the bridge, and it is the reason the value is now
+ * produced by the engine rather than smuggled in as a string.
+ */
+export function asChangedFilesValue(set: ChangedSet): string {
+  return set.present.join(",");
+}

--- a/src/staydevops-ts.ts
+++ b/src/staydevops-ts.ts
@@ -9,6 +9,7 @@ import {
   func,
   object,
 } from "@dagger.io/dagger";
+import { changedBetween } from "#checks/git-changed.js";
 import { checkPrTitleFromEvent } from "#checks/pr-checks.js";
 import {
   deleteFirebaseApphostingBackend,
@@ -157,13 +158,17 @@ export class Checks {
     nodeAuthToken?: Secret,
     runAffected = false,
   ): Promise<void> {
-    await runNodeChecks(this.resolveSource(source), this.resolveNodeAuthToken(nodeAuthToken), {
-      packagePaths: this.packagePaths,
-      registryScope: this.registryScope,
-      nodeMaxOldSpaceMb: this.heap,
-      format: true,
-      runAffected,
-    });
+    await runNodeChecks(
+      this.resolveSource(source),
+      this.resolveNodeAuthToken(nodeAuthToken),
+      {
+        packagePaths: this.packagePaths,
+        registryScope: this.registryScope,
+        nodeMaxOldSpaceMb: this.heap,
+        format: true,
+        runAffected,
+      },
+    );
   }
 
   @check()
@@ -202,13 +207,17 @@ export class Checks {
     nodeAuthToken?: Secret,
     runAffected = false,
   ): Promise<void> {
-    await runNodeChecks(this.resolveSource(source), this.resolveNodeAuthToken(nodeAuthToken), {
-      packagePaths: this.packagePaths,
-      registryScope: this.registryScope,
-      nodeMaxOldSpaceMb: this.heap,
-      lint: true,
-      runAffected,
-    });
+    await runNodeChecks(
+      this.resolveSource(source),
+      this.resolveNodeAuthToken(nodeAuthToken),
+      {
+        packagePaths: this.packagePaths,
+        registryScope: this.registryScope,
+        nodeMaxOldSpaceMb: this.heap,
+        lint: true,
+        runAffected,
+      },
+    );
   }
 
   @check()
@@ -246,13 +255,17 @@ export class Checks {
     source: Directory,
     nodeAuthToken?: Secret,
   ): Promise<void> {
-    await runNodeChecks(this.resolveSource(source), this.resolveNodeAuthToken(nodeAuthToken), {
-      packagePaths: this.packagePaths,
-      registryScope: this.registryScope,
-      nodeMaxOldSpaceMb: this.heap,
-      build: true,
-      runAffected: false,
-    });
+    await runNodeChecks(
+      this.resolveSource(source),
+      this.resolveNodeAuthToken(nodeAuthToken),
+      {
+        packagePaths: this.packagePaths,
+        registryScope: this.registryScope,
+        nodeMaxOldSpaceMb: this.heap,
+        build: true,
+        runAffected: false,
+      },
+    );
   }
 
   @check()
@@ -306,16 +319,20 @@ export class Checks {
     base = "origin/main",
     changedFiles = "",
   ): Promise<void> {
-    await runNodeChecks(this.resolveSource(source), this.resolveNodeAuthToken(nodeAuthToken), {
-      packagePaths: this.packagePaths,
-      registryScope: this.registryScope,
-      nodeMaxOldSpaceMb: this.heap,
-      test: true,
-      runAffected,
-      testScript,
-      base,
-      changedFiles,
-    });
+    await runNodeChecks(
+      this.resolveSource(source),
+      this.resolveNodeAuthToken(nodeAuthToken),
+      {
+        packagePaths: this.packagePaths,
+        registryScope: this.registryScope,
+        nodeMaxOldSpaceMb: this.heap,
+        test: true,
+        runAffected,
+        testScript,
+        base,
+        changedFiles,
+      },
+    );
   }
 
   @check()
@@ -382,6 +399,43 @@ export class Checks {
       changedFiles: this.changedFiles,
       includeDependents: false,
     });
+  }
+
+  /**
+   * Resolve the changed set from git, inside the engine.
+   *
+   * Returns JSON: added, modified, removed, and present (added + modified).
+   *
+   * The caller currently computes this on the host and passes a comma-joined
+   * string. That string has to travel through a Dagger local default, where
+   * `env://` is a *secret provider* URI -- it resolves for Secret arguments and
+   * passes through verbatim for plain strings. The changed set is a string, so
+   * it arrived as the literal "env://CHANGED_FILES" and every consumer failed
+   * silently: the scoped scripts filtered the phantom path out and reported
+   * "no changes -- skip", while staytest read it as a root-level change and
+   * escalated to every package.
+   *
+   * Resolving here makes it a typed value that cannot quietly be the wrong
+   * thing, needs no `.git` in the check container, and is cached on the commit
+   * digests.
+   *
+   * Removed paths are reported but kept out of `present`, because prettier and
+   * eslint error on a path that is not on disk. They are still worth surfacing:
+   * the shell resolvers drop deletions entirely, so a delete-only change gets
+   * no scoped checking at all.
+   *
+   * @example
+   * dagger call checks changed-from-git --url https://github.com/o/r --base origin/main
+   */
+  @func()
+  async changedFromGit(
+    url: string,
+    base = "origin/main",
+    head?: string,
+    token?: Secret,
+  ): Promise<string> {
+    const set = await changedBetween({ url, base, head, token });
+    return JSON.stringify(set, null, 2);
   }
 }
 


### PR DESCRIPTION
Closes #187

Suggested by @StaytunedLLP — Dagger's `GitRepository` type is a better answer
than passing the changed set in as a string.

### Why the string form had to go

`env://` is a Dagger **secret provider** URI. It resolves for `Secret`-typed
arguments and is passed through verbatim for plain strings:

```
NODEAUTHTOKEN=env://NODE_AUTH_TOKEN     Secret -> resolves
CHANGEDFILES=env://CHANGED_FILES        string -> literal text
```

The token half worked, so nothing looked broken while every scoped check quietly
checked nothing and staytest escalated to every package. Two published
measurements were invalid as a result and have been retracted.

The string form also needs `.git` in the container — 5–12x the tracked source,
with a digest that changes every commit, re-materialised per check.

### What this does instead

```ts
tree({ discardGitDir: true, depth: 1 })   // content, no history
headTree.changes(baseTree)                // -> Changeset
addedPaths ∪ modifiedPaths                // -> present
removedPaths                              // reported separately
```

`git.uncommitted()` returns a changeset directly, which **is** the local
profile — replacing merge-base + `ls-files --others` hand-written in three
repositories and already diverging.

### Verified against ground truth, not by the call succeeding

```
$ git diff --name-status v1.11.0 v1.12.0
M package.json
M src/checks/affected-node-tests.runtime.ts
M src/checks/node-checks.ts
M src/checks/types.ts
M src/staydevops-ts.ts          -> 5 modified, 0 added, 0 removed
```

```
$ dagger call checks changed-from-git --url ... --base v1.11.0 --head v1.12.0
{ "added": [], "removed": [],
  "modified": [ ...the same five paths... ] }
```

Exact match. A local fixture with one added, one modified, one deleted and one
unchanged file also sorts each into the right bucket and omits the unchanged
one. Private access confirmed with `--http-auth-token` against staydevops (38
real entries).

Every API name was taken from the SDK typings rather than the docs page — the
docs do not mention token auth or a native diff, and both exist.

### Not switched over yet

The existing `CHANGED_FILES` path is untouched and `asChangedFilesValue`
bridges to it. Given two invalid measurements today, the old path stays until the
new one is proven in CI and can be compared against something real.

One cost to know: a cold `tree()` clone measured ~12s. Cached on commit digest,
but the first run per commit is not free, and that wants measuring rather than
assuming.
