### PR TITLE
feat(checks): add the local profile, limited to the check that exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "format:incremental": "echo 'No incremental format check required for daggerverse'",
     "test": "echo 'No tests defined for daggerverse'",
     "verify:incremental": "npm run build",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "build:local": "npm run build",
+    "check:local": "npm run build:local"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
Closes #190

Completes the local column for the last of the five repositories.

Deliberately **only the build**. `lint`, `format:check` and `test` are stubs here
-- they echo "no check required" -- so wrapping them would produce a
`check:local` that reports success while running three echo statements. A local
profile that cannot fail is worse than not having one, which is exactly the
lesson from the scoped checks that silently stopped checking anything earlier
today.

### Worth knowing

The absent checks are filed as #189. This repository holds the shared check and
release logic five other repositories depend on, has **0 test files**, and
prettier is not even a dependency. That also corrects a comparison I drew
earlier: daggerverse running its checks in 94-129s against 10-50 minutes
elsewhere was attributed mostly to its 4 MB `.git`, but the larger reason is
that there is almost nothing here to check.
