### PR TITLE
perf(checks): lower the Node heap ceiling from 4096 to 1536 MiB

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -5,8 +5,27 @@ export const DEFAULT_PLAYWRIGHT_CACHE = "playwright-cache-node24";
 export const DEFAULT_NPM_CACHE_PATH = "/root/.npm";
 export const DEFAULT_PLAYWRIGHT_CACHE_PATH = "/root/.cache/ms-playwright";
 export const DEFAULT_REGISTRY_SCOPE = "staytunedllp";
-/** Node heap ceiling in MiB, assuming one check runs at a time. */
-export const DEFAULT_NODE_MAX_OLD_SPACE_MB = 4096;
+/**
+ * Node heap ceiling in MiB.
+ *
+ * 4096 was chosen assuming one check runs at a time, and that assumption is why
+ * the checks are serial: four concurrent Node processes each believing they may
+ * take 4 GiB will exhaust any of these hosts, which have 7.7 GiB total, four
+ * cores, and a Dagger engine holding roughly 2.4 GiB of it.
+ *
+ * Measured instead: the Node processes inside the check containers peaked around
+ * 650 MB. The ceiling was six times the observed need, and that headroom is what
+ * allowed three concurrent jobs to OOM-kill each other -- one such kill
+ * cancelled a run after 14 minutes with no diagnostic, because a signal death
+ * was being reported as a plain exit 1.
+ *
+ * 1536 leaves better than double the measured peak. It is deliberately not
+ * tuned to the peak: a heap ceiling that is too low trades an OOM kill for heap
+ * exhaustion inside tsc or eslint, which fails less legibly. If a specific check
+ * needs more, raise it for that check via nodeMaxOldSpaceMb rather than lifting
+ * this again.
+ */
+export const DEFAULT_NODE_MAX_OLD_SPACE_MB = 1536;
 export const DEFAULT_PLAYWRIGHT_BROWSERS = ["chromium"];
 export const STRICT_SHELL_HEADER = "set -euo pipefail";
 export const DEFAULT_SOURCE_EXCLUDES = [


### PR DESCRIPTION
Closes #194

Phase 5 of StaytunedLLP/staydevops#782.

### The number and why it was wrong

4096 was chosen "assuming one check runs at a time" — and that assumption is
precisely why the checks are serial. Four concurrent Node processes each
believing they may take 4 GiB will exhaust a 7.7 GiB host running a 2.4 GiB
engine on four cores.

Measured: the container Node processes peaked around **650 MB**. Six times
smaller than the ceiling, and that gap is what let three concurrent jobs
OOM-kill each other.

### Why 1536 and not 800

Too low trades an OOM kill for heap exhaustion inside tsc or eslint, which fails
less legibly. I declined this change earlier today on exactly that basis; the
measurement is what shifted it. Both the number and the reasoning are in the
constant so the next person inherits the argument, not just the value.

### This PR cannot verify itself

This repository's checks are stubs, so its CI will go green without ever
exercising a heap ceiling. A local run against staystack hung at nine minutes
with no output and was abandoned.

**So this is unverified.** The verification is a consumer CI run after tag and
pin, and it stays an unchecked criterion on #194 until that happens. Given two
measurements were retracted today for being taken on checks that were silently
doing nothing, shipping this as "tested" would repeat the mistake.
