### PR TITLE
fix(release): release only when something has actually landed

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -34,7 +34,9 @@ export async function readPackageJsonAtPath(
   let content: string;
 
   try {
-    content = await source.file(packageFilePath(packagePath, "package.json")).contents();
+    content = await source
+      .file(packageFilePath(packagePath, "package.json"))
+      .contents();
   } catch {
     throw new Error(
       `Missing package.json in the source directory at "${packagePath}".`,
@@ -221,9 +223,7 @@ export async function readBaseBranchPackageJson(
     typeof (manifest as Partial<PackageManifest>).version !== "string" ||
     (manifest as Partial<PackageManifest>).version?.trim().length === 0
   ) {
-    throw new Error(
-      `Invalid package.json in base branch at "${packagePath}".`,
-    );
+    throw new Error(`Invalid package.json in base branch at "${packagePath}".`);
   }
 
   const typedManifest = manifest as Partial<PackageManifest>;
@@ -305,6 +305,66 @@ async function ghQuery(
 /**
  * Reports whether a git tag already exists on the remote.
  */
+/**
+ * Matches the commit the release flow itself creates, so it is not counted as a
+ * reason to cut another release.
+ */
+const RELEASE_COMMIT_PATTERN = /^chore\(release\):/i;
+
+/**
+ * Counts commits on the release branch that are not release commits themselves.
+ *
+ * The hourly flow needs to answer "has anything landed since the last release",
+ * and the obvious proxies do not. Checking whether the *next* tag exists asks a
+ * question whose answer is almost always no, so every hour looked like it had
+ * work to do; the result was a stream of releases whose only content was their
+ * own version bump -- v1.12.2 contained exactly one commit, the commit that
+ * created it.
+ *
+ * Release commits are excluded by message, because counting them means the
+ * previous bump reads as a change and the loop simply moves one step along.
+ *
+ * Returns null when the comparison cannot be made -- no previous tag, or an
+ * unreadable response. The caller treats that as "release", because refusing to
+ * release on a failed lookup would stall the train silently, which is the worse
+ * of the two mistakes.
+ */
+export async function countReleasableCommits(
+  githubToken: Secret,
+  repoOwner: string,
+  repoName: string,
+  fromRef: string,
+  toRef: string,
+): Promise<number | null> {
+  const out = await ghQuery(
+    githubToken,
+    repoOwner,
+    repoName,
+    // --paginate so a busy hour is not truncated at the default page size.
+    // One line per commit: the subject only. A full message carries trailers
+    // such as Co-authored-by, and splitting the response on newlines would count
+    // each trailer as its own commit -- which fails the release-commit test, so a
+    // release whose only content was its own bump still looked releasable.
+    `gh api --paginate "repos/${repoOwner}/${repoName}/compare/${fromRef}...${toRef}" --jq '.commits[].commit.message | split("\\n")[0]' 2>/dev/null || true`,
+  );
+
+  if (!out) {
+    return null;
+  }
+
+  const messages = out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (messages.length === 0) {
+    return 0;
+  }
+
+  return messages.filter((message) => !RELEASE_COMMIT_PATTERN.test(message))
+    .length;
+}
+
 export async function checkTagExists(
   githubToken: Secret,
   repoOwner: string,
@@ -384,11 +444,7 @@ export async function createGithubRelease(
  * Separate from ghQuery: that one swallows failures because a missing tag is a
  * legitimate answer. Anything that mutates has to surface its error instead.
  */
-function ghContainer(
-  githubToken: Secret,
-  repoOwner: string,
-  repoName: string,
-) {
+function ghContainer(githubToken: Secret, repoOwner: string, repoName: string) {
   return dag
     .container()
     .from("alpine/git:latest")

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -4,6 +4,7 @@ import {
   checkRegistryVersion,
   checkReleaseExists,
   checkTagExists,
+  countReleasableCommits,
   createGithubRelease,
   createReleaseBranchWithCommit,
   createReleaseIssue,
@@ -63,11 +64,15 @@ function resolveRegistryScope(
 }
 
 function packageWorkspacePath(packagePath: string): string {
-  return packagePath === "." ? SYNC_WORKSPACE : path.posix.join(SYNC_WORKSPACE, packagePath);
+  return packagePath === "."
+    ? SYNC_WORKSPACE
+    : path.posix.join(SYNC_WORKSPACE, packagePath);
 }
 
 function packageRepoPath(packagePath: string): string {
-  return packagePath === "." ? GIT_REPO_ROOT : path.posix.join(GIT_REPO_ROOT, packagePath);
+  return packagePath === "."
+    ? GIT_REPO_ROOT
+    : path.posix.join(GIT_REPO_ROOT, packagePath);
 }
 
 async function pushUpdatedPackageFiles(
@@ -77,17 +82,21 @@ async function pushUpdatedPackageFiles(
   commitMessage: string,
 ): Promise<{ commitSha: string }> {
   if (!options.prBranch) {
-    throw new Error("prBranch is required when committing the PR version bump.");
+    throw new Error(
+      "prBranch is required when committing the PR version bump.",
+    );
   }
 
   const packagePath = options.packagePath ?? ".";
   const repoPath = packageRepoPath(packagePath);
-  const packageJsonPath = packagePath === "."
-    ? "package.json"
-    : path.posix.join(packagePath, "package.json");
-  const packageLockPath = packagePath === "."
-    ? "package-lock.json"
-    : path.posix.join(packagePath, "package-lock.json");
+  const packageJsonPath =
+    packagePath === "."
+      ? "package.json"
+      : path.posix.join(packagePath, "package.json");
+  const packageLockPath =
+    packagePath === "."
+      ? "package-lock.json"
+      : path.posix.join(packagePath, "package-lock.json");
   const updatedFilter = {
     include: [packageJsonPath, packageLockPath],
   };
@@ -174,7 +183,11 @@ async function syncPrVersion(
   );
   const manifest = await readPackageJsonAtPath(options.source, packagePath);
 
-  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+  await ensureFileExistsAtPath(
+    options.source,
+    packagePath,
+    "package-lock.json",
+  );
   parseExactVersion(mainManifest.version);
   parseExactVersion(manifest.version);
 
@@ -198,7 +211,9 @@ async function syncPrVersion(
     workspace: SYNC_WORKSPACE,
     packagePaths: packagePath,
   });
-  container = requirePackageLock(container, packagePath, { workspace: SYNC_WORKSPACE });
+  container = requirePackageLock(container, packagePath, {
+    workspace: SYNC_WORKSPACE,
+  });
   container = container.withExec([
     "bash",
     "-lc",
@@ -240,7 +255,11 @@ async function publishRelease(
     options.registryScope,
   );
 
-  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+  await ensureFileExistsAtPath(
+    options.source,
+    packagePath,
+    "package-lock.json",
+  );
   parseExactVersion(manifest.version);
 
   const tagName = `v${manifest.version}`;
@@ -354,7 +373,7 @@ async function publishRelease(
     [
       STRICT_SHELL_HEADER,
       `package_dir=${shellQuote(path.posix.join(DEFAULT_WORKSPACE, packagePath))}`,
-      "mkdir -p \"$package_dir\"",
+      'mkdir -p "$package_dir"',
       "cat > \"$package_dir/.npmrc\" <<'EOF'",
       "registry=https://npm.pkg.github.com",
       `@${registryScope}:registry=https://npm.pkg.github.com`,
@@ -415,13 +434,18 @@ async function prepareHourlyRelease(
   // Reject a non-exact version before computing anything from it. A range or
   // prerelease here would produce a nonsense tag.
   parseExactVersion(manifest.version);
-  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+  await ensureFileExistsAtPath(
+    options.source,
+    packagePath,
+    "package-lock.json",
+  );
 
   const nextVersion = nextPatchVersion(manifest.version);
   const tagName = `v${nextVersion}`;
 
-  // If the tag this run would produce already exists, the previous hour's
-  // release landed and nothing new has been merged since.
+  // Guard one: the tag this run would produce already exists. That is the
+  // repair case -- a release was cut but the manifest never moved -- not the
+  // ordinary one.
   const alreadyReleased = await checkTagExists(
     options.githubToken,
     options.repoOwner,
@@ -438,6 +462,39 @@ async function prepareHourlyRelease(
       tagName,
       releaseNeeded: false,
       reason: `Tag ${tagName} already exists; nothing to release.`,
+    };
+  }
+
+  // Guard two, and the one that actually decides most hours: has anything
+  // landed since the last release?
+  //
+  // This used to be inferred from the absence of the *next* tag, which is a
+  // question whose answer is almost always no -- so every hour looked like it
+  // had work, and produced a release whose only content was its own version
+  // bump. daggerverse v1.12.2 contained exactly one commit: the commit that
+  // created it. Each of those also spends a full check run on a runner pool
+  // that is not keeping up as it is.
+  const currentTag = `v${manifest.version}`;
+  const releasableCommits = await countReleasableCommits(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    currentTag,
+    options.baseBranch ?? "main",
+  );
+
+  // null means the comparison could not be made -- no previous tag, or an
+  // unreadable response. Release in that case: refusing on a failed lookup
+  // would stall the train silently, which is the worse of the two mistakes.
+  if (releasableCommits === 0) {
+    return {
+      action: "prepare-hourly-release",
+      packageName: manifest.name,
+      currentVersion: manifest.version,
+      nextVersion,
+      tagName,
+      releaseNeeded: false,
+      reason: `No commits on ${options.baseBranch ?? "main"} since ${currentTag}; nothing to release.`,
     };
   }
 
@@ -494,7 +551,11 @@ async function hourlyRelease(
   const manifest = await readPackageJsonAtPath(options.source, packagePath);
 
   parseExactVersion(manifest.version);
-  await ensureFileExistsAtPath(options.source, packagePath, "package-lock.json");
+  await ensureFileExistsAtPath(
+    options.source,
+    packagePath,
+    "package-lock.json",
+  );
 
   const nextVersion = nextPatchVersion(manifest.version);
   const tagName = `v${nextVersion}`;
@@ -583,10 +644,7 @@ async function hourlyRelease(
     };
   }
 
-  const stamp = new Date()
-    .toISOString()
-    .replace(/[-:T]/g, "")
-    .slice(0, 10);
+  const stamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 10);
   const branch = `${RELEASE_BRANCH_PREFIX}${stamp}`;
   const message = `chore(release): hourly v${nextVersion}`;
 
@@ -598,7 +656,10 @@ async function hourlyRelease(
     baseBranch,
     message,
     [
-      { path: manifestFile, contents: `${JSON.stringify(manifestJson, null, 2)}\n` },
+      {
+        path: manifestFile,
+        contents: `${JSON.stringify(manifestJson, null, 2)}\n`,
+      },
       { path: lockFile, contents: `${JSON.stringify(lockJson, null, 2)}\n` },
     ],
   );
@@ -648,9 +709,10 @@ async function hourlyRelease(
   return {
     ...base,
     outcome: "opened",
-    reason: base.autoMergeRequested && !autoMergeEnabled
-      ? `Opened release pull request for ${nextVersion}. Auto-merge is unavailable in this repository, so it needs a manual merge.`
-      : `Opened release pull request for ${nextVersion}.`,
+    reason:
+      base.autoMergeRequested && !autoMergeEnabled
+        ? `Opened release pull request for ${nextVersion}. Auto-merge is unavailable in this repository, so it needs a manual merge.`
+        : `Opened release pull request for ${nextVersion}.`,
     prUrl,
     branch,
     commitSha,


### PR DESCRIPTION
Closes #200

Raised by @StaytunedLLP: why release hourly when nothing changed?

The answer is that the guard never checked. It asked whether the tag it was
about to create already existed:

```ts
// If the tag this run would produce already exists, the previous hour's
// release landed and nothing new has been merged since.
const alreadyReleased = await checkTagExists(..., tagName);
```

That answer is almost always **no** — the tag being checked is always the one
that has not been created yet. So nearly every hour looked like it had work, and
produced a release whose only content was its own version bump:

```
$ git log --oneline v1.12.1..v1.12.2
ac713dd chore(release): hourly v1.12.2 (#197)
```

One commit. The comment claimed the guard meant "nothing new has been merged".
It never checked that, and I never tested the no-changes case — only the case
where real commits were pending, where it correctly said release.

### The fix

Compare the current version's tag against the release branch and count commits
that are not release commits themselves.

### A bug in the first attempt, worth recording

Only the **first line** of each commit message is compared. A full message
carries trailers like `Co-authored-by`, and splitting the API response on
newlines counts each trailer as its own commit — which fails the release-commit
test, so the empty release still looked releasable. My first version did exactly
that, and only a real comparison against v1.12.1..v1.12.2 exposed it.

### Verified against real history

| Range | Commits | Real | Verdict |
| --- | --- | --- | --- |
| `v1.12.1..v1.12.2` | 1 | **0** | **SKIP** |
| `v1.12.2..main` | 1 | 1 | RELEASE |

A failed lookup releases rather than skipping — refusing on an unreadable
response would stall the release train silently, which is the worse mistake.
