### PR TITLE
fix(release): tell zero commits apart from a failed lookup, and pin the owner

### DIFF
--- a/src/publish/helpers.ts
+++ b/src/publish/helpers.ts
@@ -345,24 +345,38 @@ export async function countReleasableCommits(
     // such as Co-authored-by, and splitting the response on newlines would count
     // each trailer as its own commit -- which fails the release-commit test, so a
     // release whose only content was its own bump still looked releasable.
-    `gh api --paginate "repos/${repoOwner}/${repoName}/compare/${fromRef}...${toRef}" --jq '.commits[].commit.message | split("\\n")[0]' 2>/dev/null || true`,
+    // A count line first, then one subject per commit. Without the count,
+    // zero commits and a failed call are the same empty string, and this
+    // cannot tell "nothing to release" from "could not tell" -- it defaulted
+    // to releasing, so the one case the guard exists to catch was the case it
+    // let through.
+    `gh api --paginate "repos/${repoOwner}/${repoName}/compare/${fromRef}...${toRef}" --jq '"COUNT:" + (.commits | length | tostring), (.commits[].commit.message | split("\\n")[0])' 2>/dev/null || true`,
   );
 
-  if (!out) {
-    return null;
-  }
-
-  const messages = out
+  const lines = out
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  if (messages.length === 0) {
+  const countLine = lines.find((line) => line.startsWith("COUNT:"));
+  if (!countLine) {
+    // No count means the call did not answer at all. Distinct from a count of
+    // zero, and the caller treats it as "release" rather than stalling the
+    // train on an unreadable response.
+    return null;
+  }
+
+  const total = Number.parseInt(countLine.slice("COUNT:".length), 10);
+  if (!Number.isFinite(total)) {
+    return null;
+  }
+  if (total === 0) {
     return 0;
   }
 
-  return messages.filter((message) => !RELEASE_COMMIT_PATTERN.test(message))
-    .length;
+  return lines
+    .filter((line) => line !== countLine)
+    .filter((message) => !RELEASE_COMMIT_PATTERN.test(message)).length;
 }
 
 export async function checkTagExists(

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -792,9 +792,33 @@ async function githubOnlyRelease(
  * mutate remote state and are idempotent, so an hourly schedule can re-run
  * them safely.
  */
+/**
+ * The only organisation this module may release for.
+ *
+ * Every action here creates tags, GitHub Releases and registry packages using
+ * repoOwner, which arrives as a plain string from the caller's workflow --
+ * `github.repository_owner`. That is trustworthy in this organisation's own
+ * workflows and is not trustworthy in general: a fork, a copied workflow, or a
+ * mistyped input would point the whole release machinery, holding a token that
+ * can write tags and packages, at a repository nobody intended.
+ *
+ * Refusing anything else costs nothing here and makes the blast radius of a
+ * wrong owner a failed run rather than a release somewhere else.
+ */
+const ALLOWED_REPO_OWNER = "StaytunedLLP";
+
 export async function releasePackage(
   options: ReleasePackageOptions,
 ): Promise<string> {
+  // Checked once, at the single entry point every action passes through,
+  // rather than in each of them.
+  if (options.repoOwner !== ALLOWED_REPO_OWNER) {
+    throw new Error(
+      `Refusing to release for owner "${options.repoOwner}": this module only releases for ${ALLOWED_REPO_OWNER}. ` +
+        "If the organisation has genuinely changed, change ALLOWED_REPO_OWNER deliberately rather than passing a different value.",
+    );
+  }
+
   let result: ReleasePackageResult;
 
   switch (options.action) {


### PR DESCRIPTION
Closes #206

The guard I shipped in v1.12.3 **did not work**. daggerverse opened an empty
`v1.12.4` at 08:52 on 2026-08-03 — thirty-five minutes after the pin carrying it
reached consumers — and staystack and gonow.travel did the same.

### Why

```
--jq '.commits[].commit.message | split("\n")[0]'
```

**Zero commits produces empty output. So does a failed call.** The function could
not tell them apart, and it treats "could not tell" as *release* — deliberately,
since refusing on an unreadable response would stall the train silently.

So the one case the guard exists to catch was the case it let through, every
time. I verified the guard against ranges that had commits and against a range
that did not exist; I never verified the range that returns exactly zero.

### Fix

A count line before the subjects, so zero is a fact rather than an absence.

| Comparison | Result |
| --- | --- |
| `daggerverse v1.12.3...main` | `COUNT:0` -> **SKIP** |
| `staylook v1.3.31...main` | `COUNT:25`, 22 real -> RELEASE |

The first row is the exact comparison that produced the empty `v1.12.4`.

### Also: releases are now restricted to StaytunedLLP

Requested by @StaytunedLLP. Every action creates tags, Releases and registry
packages using `repoOwner`, taken on trust from `github.repository_owner`. That
is fine in this org and not fine in general — a fork, a copied workflow or a
mistyped input would aim the release machinery, holding a token that can write
tags and packages, at a repository nobody intended. Checked once at the entry
point every action passes through.
