### PR TITLE
fix(release): put the empty-release guard in the function workflows call

### DIFF
--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -614,6 +614,39 @@ async function hourlyRelease(
     };
   }
 
+  // Guard two, and the one that decides most hours: has anything actually
+  // landed since the last release?
+  //
+  // Guard one asks whether the *next* tag exists, a question whose answer is
+  // almost always no -- so every hour looked like it had work and produced a
+  // release whose only content was its own version bump. #209 was exactly
+  // that: one commit, the bump that created it.
+  //
+  // This same guard sat in prepareHourlyRelease across three attempted fixes
+  // and never executed once, because every workflow passes
+  // --action=hourly-release, which lands here instead. A guard in a function
+  // nothing calls is indistinguishable from no guard at all -- and it reads as
+  // fixed, which is worse.
+  const currentTag = `v${manifest.version}`;
+  const releasableCommits = await countReleasableCommits(
+    options.githubToken,
+    options.repoOwner,
+    options.repoName,
+    currentTag,
+    baseBranch,
+  );
+
+  // null means the comparison could not be made -- no previous tag, or an
+  // unreadable response. Release in that case: refusing on a failed lookup
+  // would stall the train silently, which is the worse of the two mistakes.
+  if (releasableCommits === 0) {
+    return {
+      ...base,
+      outcome: "nothing-to-release",
+      reason: `No commits on ${baseBranch} since ${currentTag}; nothing to release.`,
+    };
+  }
+
   const manifestFile = packageFilePath(packagePath, "package.json");
   const lockFile = packageFilePath(packagePath, "package-lock.json");
 


### PR DESCRIPTION
## What

Moves the "nothing to release" guard into `hourlyRelease()`, which is the function every workflow actually reaches.

## Why

The guard has been added three times and has never executed.

All callers pass `--action=hourly-release`, which dispatches to `hourlyRelease()`. The guard was written into `prepareHourlyRelease()` — a sibling reached only by `--action=prepare-hourly-release`, which nothing uses. Each attempt read correctly, shipped, and did nothing.

The evidence: `v1.12.4` (containing the second attempt) was tagged at `05:51:56Z`. PR #209 was opened at `07:27:25Z` — 95 minutes later, by a run whose head SHA *was* `v1.12.4` — containing exactly one commit, its own version bump.

That also explains the 9 consecutive `Release Hourly` failures since 08-04 15:10: they are the stall guard correctly refusing to proceed past #209, which should never have existed. #209 is now closed.

## Verification

Run against the live repositories, both directions, before and after:

| repo | state | before | after |
|---|---|---|---|
| daggerverse | `main == v1.12.4`, 0 releasable commits | `"Would release 1.12.5."` | `"No commits on main since v1.12.4; nothing to release."` |
| staylook | 2 real commits since `v1.3.36` | — | `"Would release 1.3.37."` |

The staylook run is the one that matters: a guard that never releases is as broken as one that always does.

## Follow-up

The consumer repositories pin `daggerverse@v1.12.4` in the reusable workflow default, so they keep the broken behaviour until this is tagged as `v1.12.5` and the pins move. daggerverse itself uses the local module and is fixed on merge.

This class of bug — a change that reports success while executing nothing — is the third of its kind here, and there are still no tests in this repository (#189).

Closes #206

